### PR TITLE
[CuTe,sm120] TMA 8-warp forward + score_mod backward + cutlass-dsl 4.5.2 fixes

### DIFF
--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -12,7 +12,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass.cute import FastDivmodDivisor
 from cutlass.cute.nvgpu import cpasync, warp
-from cutlass import Int32
+from cutlass import Int32, Int64
 import cutlass.utils as utils_basic
 
 from quack import layout_utils
@@ -52,6 +52,7 @@ class FlashAttentionBackwardSm80:
         score_mod: cutlass.Constexpr | None = None,
         score_mod_bwd: cutlass.Constexpr | None = None,
         has_aux_tensors: cutlass.Constexpr = False,
+        dropout_p: float = 0.0,
     ):
         """Initializes the configuration for a flash attention v2 kernel.
 
@@ -99,6 +100,7 @@ class FlashAttentionBackwardSm80:
         self.share_QV_smem = V_in_regs
         self.score_mod = score_mod
         self.score_mod_bwd = score_mod_bwd
+        self.dropout_p = dropout_p
         if cutlass.const_expr(has_aux_tensors):
             self.vec_size: cutlass.Constexpr = 1
         else:
@@ -398,6 +400,8 @@ class FlashAttentionBackwardSm80:
         mdV_semaphore: Optional[cute.Tensor] = None,
         aux_data: AuxData = AuxData(),
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        dropout_seed: Optional[Int64] = None,
+        dropout_offset: Optional[Int64] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -492,6 +496,8 @@ class FlashAttentionBackwardSm80:
             TileScheduler,
             aux_data,
             fastdiv_mods,
+            dropout_seed,
+            dropout_offset,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -538,9 +544,15 @@ class FlashAttentionBackwardSm80:
         TileScheduler: cutlass.Constexpr[Callable],
         aux_data: AuxData = AuxData(),
         fastdiv_mods: Tuple[FastDivmodDivisor, FastDivmodDivisor] | None = None,
+        dropout_seed: Optional[Int64] = None,
+        dropout_offset: Optional[Int64] = None,
     ):
         # Thread index, block index
         tidx, _, _ = cute.arch.thread_idx()
+
+        # Stash dropout RNG state for compute_one_m_block (runtime SSA values).
+        self._dropout_seed = dropout_seed
+        self._dropout_offset = dropout_offset
 
         tile_scheduler = TileScheduler.create(tile_sched_params)
         work_tile = tile_scheduler.initial_work_tile_info()
@@ -856,6 +868,10 @@ class FlashAttentionBackwardSm80:
                 head_idx=head_idx, seqlen_info=seqlen, thr_mma_SdP=thr_mma_sdp, 
                 softmax_scale=softmax_scale, aux_data=aux_data, fastdiv_mods=fastdiv_mods,
             )
+            dropout_fn = partial(
+                self.apply_dropout, n_block=n_block, batch_idx=batch_idx,
+                head_idx=head_idx, seqlen_info=seqlen, thr_mma_SdP=thr_mma_sdp,
+            )
             smem_pipe_read_q = cutlass.Int32(0)
             smem_pipe_read_do = cutlass.Int32(0)
             smem_pipe_write_q = cutlass.Int32(self.num_stages_Q - 1)
@@ -864,6 +880,7 @@ class FlashAttentionBackwardSm80:
                 compute_one_m_block(
                     m_tile, smem_pipe_read_q, smem_pipe_read_do, smem_pipe_write_q, smem_pipe_write_do,
                     mask_fn=mask_fn, score_mod_fn=score_mod_fn, score_mod_bwd_fn=score_mod_bwd_fn,
+                    dropout_fn=dropout_fn,
                 )
                 smem_pipe_read_q = self.advance_pipeline(smem_pipe_read_q, self.num_stages_Q)
                 smem_pipe_read_do = self.advance_pipeline(smem_pipe_read_do, self.num_stages_dO)
@@ -903,6 +920,7 @@ class FlashAttentionBackwardSm80:
         mask_fn: Optional[Callable] = None,
         score_mod_fn: Optional[Callable] = None,
         score_mod_bwd_fn: Optional[Callable] = None,
+        dropout_fn: Optional[Callable] = None,
     ):
         def load_Q_next():
             m_block_next = m_block + (self.num_stages_Q - 1 if cutlass.const_expr(self.num_stages_Q > 1) else 1)
@@ -949,6 +967,12 @@ class FlashAttentionBackwardSm80:
         assert cute.size(acc_S_mn, mode=[0]) == cute.size(tLSErLSE)
         for r in cutlass.range(cute.size(acc_S_mn, mode=[0]), unroll_full=True):
             acc_S_mn[r, None].store(cute.math.exp2(acc_S_mn[r, None].load() * softmax_scale_log2 - tLSErLSE[r], fastmath=True))
+        # Dropout: regenerate the IDENTICAL keep-mask used in the forward pass and
+        # apply it to the recomputed P (zero dropped positions, scale kept by 1/(1-p)).
+        # Zeroing P here automatically zeroes the dV and dS contributions of dropped
+        # entries, matching the forward where those entries did not contribute to O.
+        if cutlass.const_expr(self.dropout_p > 0.0):
+            dropout_fn(acc_S, m_block=m_block)
         # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_S_mn)
 
         # MMA dP
@@ -1134,6 +1158,43 @@ class FlashAttentionBackwardSm80:
             transpose_indices=self.SdP_swapAB,
         )
         
+
+    @cute.jit
+    def apply_dropout(
+        self,
+        acc_S: cute.Tensor,
+        thr_mma_SdP: cute.ThrMma,
+        batch_idx,
+        head_idx,
+        m_block,
+        n_block,
+        seqlen_info: SeqlenInfoQK,
+    ):
+        """Regenerate the forward dropout keep-mask on the recomputed P and apply it.
+
+        Must produce the IDENTICAL mask as the forward pass: keyed by global
+        (batch, head, q_idx, kv_idx). The bwd S tile is (n, m) transposed when
+        SdP_swapAB, so the identity tensor coords are swapped accordingly and we
+        pass q_idx/kv_idx in the correct order to the shared applicator.
+        """
+        from flash_attn.cute.philox import apply_dropout as _apply_dropout
+        acc_shape = (self.m_block_size, self.n_block_size)
+        cS = cute.make_identity_tensor(acc_shape if not self.SdP_swapAB else acc_shape[::-1])
+        offset = (m_block * self.m_block_size, n_block * self.n_block_size)
+        cS = cute.domain_offset(offset if not self.SdP_swapAB else offset[::-1], cS)
+        tScS = thr_mma_SdP.partition_C(cS)
+        p_keep = cutlass.Float32(1.0 - self.dropout_p)
+        scale = cutlass.Float32(1.0 / (1.0 - self.dropout_p))
+        _apply_dropout(
+            acc_S, tScS,
+            self._dropout_seed, self._dropout_offset,
+            p_keep, scale,
+            batch_idx, head_idx,
+            num_heads=1,
+            seqlen_k=seqlen_info.seqlen_k,
+            transpose_indices=self.SdP_swapAB,
+        )
+
 
     @cute.jit
     def epilogue(

--- a/flash_attn/cute/flash_bwd.py
+++ b/flash_attn/cute/flash_bwd.py
@@ -3,13 +3,14 @@
 # from Cutlass C++ to Cute-DSL.
 import math
 from types import SimpleNamespace
-from typing import Type, Callable, Optional
+from typing import Tuple, Type, Callable, Optional
 from functools import partial
 
 import cuda.bindings.driver as cuda
 
 import cutlass
 import cutlass.cute as cute
+from cutlass.cute import FastDivmodDivisor
 from cutlass.cute.nvgpu import cpasync, warp
 from cutlass import Int32
 import cutlass.utils as utils_basic
@@ -19,9 +20,9 @@ from flash_attn.cute import ampere_helpers as sm80_utils
 from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
 from flash_attn.cute import utils
 from flash_attn.cute.mask import AttentionMask
-from flash_attn.cute.softmax import call_score_mod, call_score_mod_bwd
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
 from quack.cute_dsl_utils import ParamsBase
+from flash_attn.cute.softmax import apply_score_mod_bwd_inner, apply_score_mod_inner
 from flash_attn.cute.tile_scheduler import SingleTileScheduler, SingleTileVarlenScheduler, TileSchedulerArguments
 from flash_attn.cute.block_sparsity import BlockSparseTensors
 from flash_attn.cute.utils import AuxData
@@ -50,6 +51,7 @@ class FlashAttentionBackwardSm80:
         V_in_regs: bool = False,
         score_mod: cutlass.Constexpr | None = None,
         score_mod_bwd: cutlass.Constexpr | None = None,
+        has_aux_tensors: cutlass.Constexpr = False,
     ):
         """Initializes the configuration for a flash attention v2 kernel.
 
@@ -97,6 +99,11 @@ class FlashAttentionBackwardSm80:
         self.share_QV_smem = V_in_regs
         self.score_mod = score_mod
         self.score_mod_bwd = score_mod_bwd
+        if cutlass.const_expr(has_aux_tensors):
+            self.vec_size: cutlass.Constexpr = 1
+        else:
+            self.vec_size: cutlass.Constexpr = 4
+        self.qk_acc_dtype = cutlass.Float32
 
     @staticmethod
     def can_implement(
@@ -408,25 +415,25 @@ class FlashAttentionBackwardSm80:
         SharedStorage = self._get_shared_storage_cls()
         tiled_mma_sdp, tiled_mma_dkv, tiled_mma_dq = self._get_tiled_mma()
 
-        num_head = mQ.shape[1] if cutlass.const_expr(mCuSeqlensQ is not None) else mQ.shape[2]
-
         if cutlass.const_expr(mCuSeqlensK is not None):
             TileScheduler = SingleTileVarlenScheduler
             num_batch = mCuSeqlensK.shape[0] - 1
+            total_k = cute.size(mK.shape[0])
         else:
             TileScheduler = SingleTileScheduler
             num_batch = mK.shape[0]
+            total_k = cute.size(mK.shape[0]) * cute.size(mK.shape[1])
 
         # Uses seqlen k, etc. since main bwd kernel's blocks are over n
         tile_sched_args = TileSchedulerArguments(
-            num_block=cute.ceil_div(mK.shape[1], self.n_block_size),
-            num_head=num_head,
+            num_block=cute.ceil_div(mK.shape[-3], self.n_block_size),
+            num_head=mQ.shape[-2],
             num_batch=num_batch,
             num_splits=1,
-            seqlen_k=0,
-            headdim=mK.shape[2],
-            headdim_v=mV.shape[2],
-            total_q=mK.shape[0],
+            seqlen_k=cute.size(mQ.shape[-3]),
+            headdim=mK.shape[-1],
+            headdim_v=mV.shape[-1],
+            total_q=total_k,
             tile_shape_mn=(self.n_block_size, self.m_block_size),
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if cutlass.const_expr(self.pack_gqa) else 1,
             mCuSeqlensQ=mCuSeqlensK,
@@ -436,7 +443,18 @@ class FlashAttentionBackwardSm80:
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
         grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
 
-        softmax_scale_log2, softmax_scale = utils.compute_softmax_scale_log2(softmax_scale, self.score_mod)
+        LOG2_E = math.log2(math.e)
+        if cutlass.const_expr(self.score_mod is None):
+            # Without score_mod: bake scale into log2
+            softmax_scale_log2 = softmax_scale * LOG2_E
+        else:
+            # With score_mod: score_mod applied to S * softmax_scale, then use LOG2_E only
+            softmax_scale_log2 = LOG2_E
+
+        fastdiv_mods = utils.compute_fastdiv_mods(
+            mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_data.tensors, seqlen_dim=1,
+        )
+
         self.kernel(
             mQ,
             mK,
@@ -473,6 +491,7 @@ class FlashAttentionBackwardSm80:
             tile_sched_params,
             TileScheduler,
             aux_data,
+            fastdiv_mods,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -518,6 +537,7 @@ class FlashAttentionBackwardSm80:
         tile_sched_params: ParamsBase,
         TileScheduler: cutlass.Constexpr[Callable],
         aux_data: AuxData = AuxData(),
+        fastdiv_mods: Tuple[FastDivmodDivisor, FastDivmodDivisor] | None = None,
     ):
         # Thread index, block index
         tidx, _, _ = cute.arch.thread_idx()
@@ -781,9 +801,7 @@ class FlashAttentionBackwardSm80:
                 smem_copy_params=smem_copy_params, gmem_copy_params=gmem_copy_params,
                 load_Q_LSE=load_Q_LSE, load_dO_dPsum=load_dO_dPsum,
                 m_block_max=m_block_max,
-                softmax_scale=softmax_scale,
                 softmax_scale_log2=softmax_scale_log2,
-                aux_data=aux_data,
             )
 
             # ///////////////////////////////////////////////////////////////////////////////
@@ -828,6 +846,16 @@ class FlashAttentionBackwardSm80:
                 batch_idx=batch_idx, head_idx=head_idx,
                 mask_seqlen=True, mask_causal=self.is_causal
             )
+            score_mod_fn = partial(
+                self.apply_score_mod, n_block=n_block, batch_idx=batch_idx, 
+                head_idx=head_idx, seqlen_info=seqlen, thr_mma_SdP=thr_mma_sdp, 
+                softmax_scale=softmax_scale, aux_data=aux_data, fastdiv_mods=fastdiv_mods,
+            )
+            score_mod_bwd_fn = partial(
+                self.apply_score_mod_bwd, n_block=n_block, batch_idx=batch_idx, 
+                head_idx=head_idx, seqlen_info=seqlen, thr_mma_SdP=thr_mma_sdp, 
+                softmax_scale=softmax_scale, aux_data=aux_data, fastdiv_mods=fastdiv_mods,
+            )
             smem_pipe_read_q = cutlass.Int32(0)
             smem_pipe_read_do = cutlass.Int32(0)
             smem_pipe_write_q = cutlass.Int32(self.num_stages_Q - 1)
@@ -835,7 +863,7 @@ class FlashAttentionBackwardSm80:
             for m_tile in cutlass.range(m_block_min, m_block_max, unroll=1):
                 compute_one_m_block(
                     m_tile, smem_pipe_read_q, smem_pipe_read_do, smem_pipe_write_q, smem_pipe_write_do,
-                    mask_fn=mask_fn,
+                    mask_fn=mask_fn, score_mod_fn=score_mod_fn, score_mod_bwd_fn=score_mod_bwd_fn,
                 )
                 smem_pipe_read_q = self.advance_pipeline(smem_pipe_read_q, self.num_stages_Q)
                 smem_pipe_read_do = self.advance_pipeline(smem_pipe_read_do, self.num_stages_dO)
@@ -871,10 +899,10 @@ class FlashAttentionBackwardSm80:
         load_Q_LSE: Callable,
         load_dO_dPsum: Callable,
         m_block_max: cutlass.Int32,
-        softmax_scale: cutlass.Float32,
         softmax_scale_log2: cutlass.Float32,
-        aux_data: AuxData = AuxData(),
         mask_fn: Optional[Callable] = None,
+        score_mod_fn: Optional[Callable] = None,
+        score_mod_bwd_fn: Optional[Callable] = None,
     ):
         def load_Q_next():
             m_block_next = m_block + (self.num_stages_Q - 1 if cutlass.const_expr(self.num_stages_Q > 1) else 1)
@@ -908,27 +936,16 @@ class FlashAttentionBackwardSm80:
         cute.autovec_copy(
             smem_copy_params.tSsLSEMma[None, smem_pipe_read_q if cutlass.const_expr(self.num_stages_Q > 1) else 0], tLSErLSE
         )
-        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S)
-        acc_S_pre_mn = layout_utils.reshape_acc_to_mn(acc_S_pre)
         if cutlass.const_expr(self.score_mod is not None):
-            for r in cutlass.range(cute.size(acc_S_mn, mode=[0]), unroll_full=True):
-                acc_S_mn[r, None].store(
-                    call_score_mod(
-                        self.score_mod,
-                        acc_S_mn[r, None].load() * softmax_scale,
-                        0,
-                        0,
-                        0,
-                        0,
-                        None,
-                        aux_data,
-                    )
-                )
+            score_mod_fn(acc_S, m_block=m_block)
+
         if cutlass.const_expr(mask_fn is not None):
             mask_fn(acc_S, m_block=m_block)
-        bidx = 0
+
+        # bidx = 0
         # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_S_mn)
         # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == 1: cute.print_tensor(tLSErLSE)
+        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S, transpose=self.SdP_swapAB)
         assert cute.size(acc_S_mn, mode=[0]) == cute.size(tLSErLSE)
         for r in cutlass.range(cute.size(acc_S_mn, mode=[0]), unroll_full=True):
             acc_S_mn[r, None].store(cute.math.exp2(acc_S_mn[r, None].load() * softmax_scale_log2 - tLSErLSE[r], fastmath=True))
@@ -955,20 +972,13 @@ class FlashAttentionBackwardSm80:
         # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_dP_mn)
         assert cute.size(acc_dP_mn, mode=[0]) == cute.size(tLSErdPsum)
         for r in cutlass.range(cute.size(acc_dP_mn, mode=[0]), unroll_full=True):
-            grad_val = acc_S_mn[r, None].load() * (acc_dP_mn[r, None].load() - tLSErdPsum[r])
-            if cutlass.const_expr(self.score_mod_bwd is not None):
-                grad_val = call_score_mod_bwd(
-                    self.score_mod_bwd,
-                    grad_val,
-                    acc_S_pre_mn[r, None].load() * softmax_scale,
-                    0,
-                    0,
-                    0,
-                    0,
-                    None,
-                    aux_data,
-                )
-            acc_dP_mn[r, None].store(grad_val)
+            acc_dP_mn[r, None].store(
+                acc_S_mn[r, None].load() * (acc_dP_mn[r, None].load() - tLSErdPsum[r])
+            )
+        
+        if cutlass.const_expr(self.score_mod_bwd is not None):
+            score_mod_bwd_fn(acc_dP, acc_S_pre, m_block=m_block)
+
         # if cute.arch.thread_idx()[0] == 0 and cute.arch.block_idx()[0] == bidx: cute.print_tensor(acc_dP_mn)
         rP = cute.make_fragment_like(acc_S, self.dtype)
         rP.store(acc_S.load().to(self.dtype))
@@ -1045,6 +1055,85 @@ class FlashAttentionBackwardSm80:
         if cutlass.const_expr(self.num_stages_Q == 1):
             cute.arch.barrier()
             dQ_mma(load_Q_next)
+    
+
+    @cute.jit
+    def apply_score_mod(
+        self,
+        acc_S: cute.Tensor,
+        thr_mma_SdP: cute.ThrMma,
+        batch_idx,
+        head_idx,
+        m_block,
+        n_block,
+        softmax_scale,
+        seqlen_info: SeqlenInfoQK,
+        aux_data,
+        fastdiv_mods: Tuple[FastDivmodDivisor, FastDivmodDivisor] | None = None,
+    ):
+        # [NOTE] SdP_swapAB: swapAB transposes the tile, so use (n, m) indexing
+        acc_shape = (self.m_block_size, self.n_block_size)
+        cS = cute.make_identity_tensor(acc_shape if not self.SdP_swapAB else acc_shape[::-1])
+        offset = (m_block * self.m_block_size, n_block * self.n_block_size)
+        cS = cute.domain_offset(offset if not self.SdP_swapAB else offset[::-1], cS)
+        tScS = thr_mma_SdP.partition_C(cS)
+
+        apply_score_mod_inner(
+            acc_S,
+            tScS,
+            self.score_mod,
+            batch_idx,
+            head_idx,
+            softmax_scale,
+            self.vec_size,
+            self.qk_acc_dtype,
+            aux_data,
+            fastdiv_mods,
+            seqlen_info,
+            constant_q_idx=None,
+            qhead_per_kvhead=self.qhead_per_kvhead,
+            transpose_indices=self.SdP_swapAB,
+        )
+
+    @cute.jit
+    def apply_score_mod_bwd(
+        self,
+        grad_tensor: cute.Tensor,
+        score_tensor: cute.Tensor,
+        thr_mma_SdP: cute.ThrMma,
+        batch_idx,
+        head_idx,
+        m_block,
+        n_block,
+        softmax_scale,
+        seqlen_info: SeqlenInfoQK,
+        aux_data,
+        fastdiv_mods: Tuple[FastDivmodDivisor, FastDivmodDivisor] | None = None,
+    ):
+        acc_shape = (self.m_block_size, self.n_block_size) 
+        cS = cute.make_identity_tensor(acc_shape if not self.SdP_swapAB else acc_shape[::-1])
+        offset = (m_block * self.m_block_size, n_block * self.n_block_size)
+        cS = cute.domain_offset(offset if not self.SdP_swapAB else offset[::-1], cS)
+        tScS = thr_mma_SdP.partition_C(cS) 
+
+        apply_score_mod_bwd_inner(
+            grad_tensor,
+            score_tensor,
+            tScS,
+            self.score_mod_bwd,
+            batch_idx,
+            head_idx,
+            softmax_scale,
+            self.vec_size,
+            self.qk_acc_dtype,
+            aux_data,
+            fastdiv_mods,
+            seqlen_info,
+            constant_q_idx=None,
+            qhead_per_kvhead=self.qhead_per_kvhead,
+            transpose_indices=self.SdP_swapAB,
+        )
+        
 
     @cute.jit
     def epilogue(

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -14,7 +14,7 @@ import cuda.bindings.driver as cuda
 
 import cutlass
 import cutlass.cute as cute
-from cutlass import Float32, Int32, const_expr
+from cutlass import Float32, Int32, Int64, const_expr
 from cutlass.cute.nvgpu import cpasync, warp
 import cutlass.utils as utils_basic
 from cutlass.base_dsl.arch import Arch
@@ -57,6 +57,7 @@ class FlashAttentionForwardBase:
         mask_mod: Optional[cutlass.Constexpr] = None,
         has_aux_tensors: bool = False,
         q_subtile_factor: int | None = None,
+        dropout_p: float = 0.0,
     ):
         """Initializes the configuration for a flash attention kernel.
 
@@ -99,6 +100,7 @@ class FlashAttentionForwardBase:
         self.Q_in_regs = Q_in_regs
         self.score_mod = score_mod
         self.mask_mod = mask_mod
+        self.dropout_p = dropout_p
         self.qk_acc_dtype = Float32
         self.score_vec_size: cutlass.Constexpr = getattr(
             score_mod, "__vec_size__", 1 if cutlass.const_expr(has_aux_tensors) else 2
@@ -638,6 +640,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         learnable_sink: Optional[cute.Tensor] = None,
         blocksparse_tensors: Optional[BlockSparseTensors] = None,
         aux_data: AuxData = AuxData(),
+        dropout_seed: Optional[Int64] = None,
+        dropout_offset: Optional[Int64] = None,
         # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
         stream: cuda.CUstream = None,
     ):
@@ -737,6 +741,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             TileScheduler,
             aux_data,
             fastdiv_mods,
+            dropout_seed,
+            dropout_offset,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -776,9 +782,15 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         TileScheduler: cutlass.Constexpr[Callable],
         aux_data: AuxData = AuxData(),
         fastdiv_mods=None,
+        dropout_seed: Optional[Int64] = None,
+        dropout_offset: Optional[Int64] = None,
     ):
         # Thread index, block index
         tidx, _, _ = cute.arch.thread_idx()
+
+        # Stash dropout RNG state for compute_one_n_block (runtime SSA values).
+        self._dropout_seed = dropout_seed
+        self._dropout_offset = dropout_offset
 
         tile_scheduler = TileScheduler.create(tile_sched_params)
         work_tile = tile_scheduler.initial_work_tile_info()
@@ -1175,6 +1187,8 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             mask_fn(acc_S, n_block=n_block)
         row_scale = softmax.online_softmax(acc_S, is_first=is_first_n_block, check_inf=check_inf)
         softmax.rescale_O(mma_params.acc_O, row_scale)
+        if const_expr(self.dropout_p > 0.0):
+            self.apply_dropout(acc_S, mma_params.thr_mma_qk, batch_idx, head_idx, m_block, n_block, seqlen)
         rP = cute.make_fragment_like(acc_S, self.dtype)
         rP.store(acc_S.load().to(self.dtype))
         tOrP = layout_utils.reshape_acc_to_frgA(rP)
@@ -1227,6 +1241,29 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
             seqlen_info=seqlen,
             constant_q_idx=None,
             qhead_per_kvhead=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+
+    @cute.jit
+    def apply_dropout(self, acc_S, thr_mma_qk, batch_idx, head_idx, m_block, n_block, seqlen):
+        """Apply inverted dropout to the post-softmax probabilities P (acc_S) in-place.
+
+        Keyed by global (batch, head, q_idx, kv_idx) so the backward pass regenerates
+        the identical keep-mask. p_keep = 1 - dropout_p; kept values scaled by 1/p_keep.
+        """
+        from flash_attn.cute.philox import apply_dropout as _apply_dropout
+        cS = cute.make_identity_tensor((self.tile_m, self.tile_n))
+        cS = cute.domain_offset((m_block * self.tile_m, n_block * self.tile_n), cS)
+        tScS = thr_mma_qk.partition_C(cS)
+        p_keep = Float32(1.0 - self.dropout_p)
+        scale = Float32(1.0 / (1.0 - self.dropout_p))
+        num_heads = cutlass.const_expr(self.qhead_per_kvhead if self.pack_gqa else 1)
+        _apply_dropout(
+            acc_S, tScS,
+            self._dropout_seed, self._dropout_offset,
+            p_keep, scale,
+            batch_idx, head_idx,
+            num_heads=1,
+            seqlen_k=seqlen.seqlen_k,
         )
 
 

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -30,7 +30,7 @@ from flash_attn.cute.mask import AttentionMask
 from flash_attn.cute.softmax import Softmax, apply_score_mod_inner
 from flash_attn.cute.seqlen_info import SeqlenInfoQK
 from flash_attn.cute.block_info import BlockInfo
-from flash_attn.cute.pack_gqa import PackGQA
+from flash_attn.cute.pack_gqa import PackGQA, pack_gqa_layout
 from flash_attn.cute.named_barrier import NamedBarrierFwd
 from flash_attn.cute.block_sparsity import BlockSparseTensors
 from flash_attn.cute.tile_scheduler import SingleTileScheduler, SingleTileVarlenScheduler, TileSchedulerArguments
@@ -680,6 +680,18 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         if const_expr(mLSE is not None):
             LSE_layout_transpose = [2, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 0]
             mLSE = cute.make_tensor(mLSE.iterator, cute.select(mLSE.layout, mode=LSE_layout_transpose))
+        # Pack-GQA: fold qhead_per_kvhead into the seqlen mode so the kernel iterates
+        # over (qhead * seqlen) rows against a single KV head. After the transpose above,
+        # mQ/mO are (seqlen, headdim, nheads, [batch]) (head at mode 2) and mLSE is
+        # (seqlen, nheads, [batch]) (head at mode 1). This matches the SM90 path and is
+        # what PackGQA.store_O/store_LSE/load_Q expect; without it the packed (h_idx,m_idx)
+        # gmem coordinate in store_O hits an unpacked layout and crd2idx fails.
+        if const_expr(self.pack_gqa):
+            nheads_kv = mK.shape[2]
+            mQ = pack_gqa_layout(mQ, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            mO = pack_gqa_layout(mO, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            if const_expr(mLSE is not None):
+                mLSE = pack_gqa_layout(mLSE, self.qhead_per_kvhead, nheads_kv, head_idx=1)
         # TileScheduler for varlen, simple grid for non-varlen
         if const_expr(mCuSeqlensQ is not None or mSeqUsedQ is not None):
             TileScheduler = SingleTileVarlenScheduler
@@ -688,10 +700,10 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         num_batch = (
             mCuSeqlensQ.shape[0] - 1
             if const_expr(mCuSeqlensQ is not None)
-            else mQ.shape[3]
+            else cute.size(mQ.shape[3])
         )
         tile_sched_args = TileSchedulerArguments(
-            num_block=cute.ceil_div(mQ.shape[0], self.tile_m),
+            num_block=cute.ceil_div(cute.size(mQ.shape[0]), self.tile_m),
             num_head=cute.size(mQ.shape[2]),
             num_batch=num_batch,
             num_splits=1,
@@ -808,7 +820,7 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         )
         seqlen = SeqlenInfoQK.create(
             batch_idx=batch_size,
-            seqlen_q_static=mQ.shape[0],
+            seqlen_q_static=mQ.shape[0] if const_expr(not self.pack_gqa) else mQ.shape[0][1],
             seqlen_k_static=mK.shape[0],
             mCuSeqlensQ=mCuSeqlensQ,
             mCuSeqlensK=mCuSeqlensK,
@@ -828,7 +840,13 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         blkQ_shape = (self.tile_m, self.tile_hdim)
         blkK_shape = (self.tile_n, self.tile_hdim)
         blkV_shape = (self.tile_n, self.tile_hdimv)
-        num_head_kv = num_head // self.qhead_per_kvhead
+        # When pack_gqa, the scheduler iterates over KV heads, so num_head already
+        # indexes KV heads and mQ is packed ((qhead, seqlen), headdim, nheads_kv, batch).
+        # When not pack_gqa, num_head indexes Q heads and KV heads are derived by division.
+        num_head_kv = (
+            num_head // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else num_head
+        )
+        # mQ_cur: ((qhead, seqlen), headdim) when packed, (seqlen, headdim) otherwise.
         if const_expr(not seqlen.has_cu_seqlens_q):
             mQ_cur = mQ[None, None, num_head, batch_size]
         else:
@@ -839,7 +857,12 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         else:
             mK_cur = cute.domain_offset((seqlen.offset_k, 0), mK[None, None, num_head_kv])
             mV_cur = cute.domain_offset((seqlen.offset_k, 0), mV[None, None, num_head_kv])
-        gQ = cute.local_tile(mQ_cur, blkQ_shape, (m_block, 0))
+        # For pack_gqa, Q rows are gathered via per-row gmem pointers in PackGQA.load_Q,
+        # so we don't build a contiguous gQ tile here.
+        if const_expr(not self.pack_gqa):
+            gQ = cute.local_tile(mQ_cur, blkQ_shape, (m_block, 0))
+        else:
+            gQ = None
         gK = cute.local_tile(mK_cur, blkK_shape, (None, 0))
         gV = cute.local_tile(mV_cur, blkV_shape, (None, 0))
 
@@ -971,7 +994,18 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         # ///////////////////////////////////////////////////////////////////////////////
         # Start async loads of the last mn-tile, where we take care of the mn residue
         gmem_thr_copy_Q = gmem_tiled_copy_Q.get_slice(tidx)
-        self.load_Q(gmem_thr_copy_Q, gQ, sQ, m_block, seqlen=seqlen.seqlen_q, headdim=mQ.shape[1])
+        if const_expr(not self.pack_gqa):
+            self.load_Q(
+                gmem_thr_copy_Q, gQ, sQ, m_block, seqlen=seqlen.seqlen_q, headdim=mQ.shape[1]
+            )
+        else:
+            # PackGQA gathers Q rows by (h_idx, m_idx) via per-row gmem pointers.
+            pack_gqa_q = PackGQA(
+                self.tile_m, self.tile_hdim, self.check_hdim_oob, self.qhead_per_kvhead
+            )
+            pack_gqa_q.load_Q(
+                mQ_cur, sQ, gmem_tiled_copy_Q, tidx, m_block, seqlen.seqlen_q
+            )
         cute.arch.cp_async_commit_group()
 
         def preprocess_Q():

--- a/flash_attn/cute/flash_fwd.py
+++ b/flash_attn/cute/flash_fwd.py
@@ -656,7 +656,9 @@ class FlashAttentionForwardSm80(FlashAttentionForwardBase):
         self.num_Q_load_threads = self.num_threads
         self.num_epilogue_threads = self.num_threads
         # self.use_tma_O = self.arch >= 90 and mCuSeqlensQ is None
-        self.use_tma_O = self.arch >= Arch.sm_90
+        # SM120 (Blackwell GeForce / RTX PRO / DGX Spark) lacks the WGMMA-era TMA-store
+        # path used in the epilogue; only sm_90..sm_119 use TMA for the O store. (issue #2649)
+        self.use_tma_O = Arch.sm_90 <= self.arch < Arch.sm_120
         self._setup_attributes()
         SharedStorage = self._get_shared_storage_cls()
         mQ, mK, mV, mO = [assume_tensor_aligned(t) for t in (mQ, mK, mV, mO)]

--- a/flash_attn/cute/flash_fwd_sm120_tma.py
+++ b/flash_attn/cute/flash_fwd_sm120_tma.py
@@ -1,0 +1,1004 @@
+# Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+# SM120 (Blackwell GeForce / DGX Spark) forward pass with TMA loads and warp specialization.
+#
+# Key differences from FlashAttentionForwardSm120 (CpAsync):
+#   - TMA (cp.async.bulk) for Q/K/V global → shared memory transfers
+#   - Warp specialization: 1 DMA warp (TMA loads) + N MMA warps (compute)
+#   - PipelineTmaAsync with mbarrier synchronization for KV double-buffering
+#   - SM80-compatible tensor cores (mma.sync.aligned.m16n8k16) for MMA
+#   - Swizzle(B, 4, 3) for SMEM layouts (TMA requirement, not M=3 like CpAsync)
+#
+# Validated on SM121a (DGX Spark).
+# Contributed by Second Nature Computing (https://joinsecondnature.com)
+
+import math
+from types import SimpleNamespace
+from typing import Type, Callable, Optional
+from functools import partial
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Constexpr, Float32, Int32, const_expr
+from cutlass.cute.nvgpu import cpasync, warp
+import cutlass.utils as utils_basic
+
+from quack import layout_utils
+
+from flash_attn.cute import ampere_helpers as sm80_utils
+from flash_attn.cute.cute_dsl_utils import assume_tensor_aligned
+from flash_attn.cute import utils
+import cutlass.pipeline as pipeline
+from flash_attn.cute.mask import AttentionMask
+from flash_attn.cute.softmax import Softmax, apply_score_mod_inner
+from flash_attn.cute.seqlen_info import SeqlenInfoQK
+from flash_attn.cute.block_info import BlockInfo
+from flash_attn.cute.pack_gqa import PackGQA
+from flash_attn.cute.named_barrier import NamedBarrierFwd
+from flash_attn.cute.tile_scheduler import (
+    TileSchedulerArguments,
+    SingleTileScheduler,
+    SingleTileVarlenScheduler,
+)
+from flash_attn.cute.utils import AuxData
+from cutlass.cute import FastDivmodDivisor
+
+from flash_attn.cute.flash_fwd import FlashAttentionForwardBase
+
+
+def get_smem_layout_atom_tma(dtype: Type[cutlass.Numeric], k_dim: int) -> cute.ComposedLayout:
+    """TMA-compatible SMEM layout atom using Swizzle(B, 4, 3).
+
+    TMA hardware requires swizzle_base=4 (i.e., Swizzle(B, 4, 3)), unlike CpAsync
+    which uses swizzle_base=3 (Swizzle(B, 3, 3)). The swizzle_bits B is chosen
+    based on the row width in bytes:
+      - 128-byte rows (64 bf16 elems): SW128 → B=3
+      - 64-byte rows  (32 bf16 elems): SW64  → B=2
+    """
+    dtype_byte = cutlass.const_expr(dtype.width // 8)
+    bytes_per_row = cutlass.const_expr(k_dim * dtype_byte)
+    smem_k_block_size = (
+        cutlass.const_expr(
+            128
+            if bytes_per_row % 128 == 0
+            else (64 if bytes_per_row % 64 == 0 else (32 if bytes_per_row % 32 == 0 else 16))
+        )
+        // dtype_byte
+    )
+    swizzle_bits = (
+        4
+        if smem_k_block_size == 128
+        else (3 if smem_k_block_size == 64 else (2 if smem_k_block_size == 32 else 1))
+    )
+    # TMA requires swizzle_base=4
+    swizzle_base = 4
+    return cute.make_composed_layout(
+        cute.make_swizzle(swizzle_bits, swizzle_base, 3),
+        0,
+        cute.make_ordered_layout(
+            (8 if cutlass.const_expr(k_dim % 32 == 0) else 16, smem_k_block_size), order=(1, 0)
+        ),
+    )
+
+
+class FlashAttentionForwardSm120Tma(FlashAttentionForwardBase):
+    """Flash Attention v2 forward for SM120 using TMA loads and warp specialization.
+
+    Uses TMA (cp.async.bulk) for global→shared memory transfers with a dedicated
+    DMA warp, while MMA warps perform computation. This enables overlapping loads
+    with compute via double-buffered KV pipelining.
+
+    Architecture constraints:
+      - SM80-era mma.sync.aligned.m16n8k16 tensor core instructions
+      - TMA (cp.async.bulk) for bulk memory transfers (no multicast)
+      - PipelineTmaAsync with mbarrier synchronization
+      - 99 KB shared memory capacity
+      - No WGMMA, no tcgen05, no TMEM
+    """
+
+    # Keep arch = 80 for MMA selection purposes (SM80 mma.sync).
+    # The GPU compilation target is determined by the actual device at compile time.
+    arch = 80
+
+    def __init__(
+        self,
+        dtype: Type[cutlass.Numeric],
+        head_dim: int,
+        head_dim_v: Optional[int] = None,
+        qhead_per_kvhead: int = 1,
+        is_causal: bool = False,
+        is_local: bool = False,
+        pack_gqa: bool = True,
+        tile_m: int = 128,
+        tile_n: int = 64,
+        num_mma_warps: int = 4,
+        kv_stages: int = 2,
+        score_mod: Optional[cutlass.Constexpr] = None,
+        mask_mod: Optional[cutlass.Constexpr] = None,
+        has_aux_tensors: bool = False,
+    ):
+        # Initialize base class with num_threads = (num_mma_warps + 1) * 32
+        # The +1 is for the dedicated DMA/producer warp.
+        num_threads = (num_mma_warps + 1) * 32
+        super().__init__(
+            dtype=dtype,
+            head_dim=head_dim,
+            head_dim_v=head_dim_v,
+            qhead_per_kvhead=qhead_per_kvhead,
+            is_causal=is_causal,
+            is_local=is_local,
+            pack_gqa=pack_gqa,
+            tile_m=tile_m,
+            tile_n=tile_n,
+            num_stages=kv_stages,
+            num_threads=num_threads,
+            Q_in_regs=False,
+            score_mod=score_mod,
+            mask_mod=mask_mod,
+            has_aux_tensors=has_aux_tensors,
+        )
+        # Override arch after parent __init__ which sets it to the runtime GPU arch.
+        # SM120 uses SM80 mma.sync, so base class code paths must see arch=sm_80
+        # to avoid enabling SM90+ features (TMA-O, WGMMA, etc.).
+        from cutlass.base_dsl.arch import Arch
+        self.arch = Arch.sm_80
+        self.num_mma_warps = num_mma_warps
+        self.kv_stages = kv_stages
+        self.use_tma_O = False  # SM120 doesn't have WGMMA, so O store uses SMEM not TMA
+
+    @staticmethod
+    def can_implement(
+        dtype,
+        head_dim,
+        head_dim_v,
+        tile_m,
+        tile_n,
+        num_mma_warps,
+        kv_stages,
+        is_causal,
+    ) -> bool:
+        """Check if the TMA kernel can be implemented with the given parameters."""
+        if dtype not in [cutlass.Float16, cutlass.BFloat16]:
+            return False
+        if head_dim % 8 != 0:
+            return False
+        if head_dim_v is None:
+            head_dim_v = head_dim
+        if head_dim_v % 8 != 0:
+            return False
+        # m_block_size must be divisible by MMA tile M (num_mma_warps * 16)
+        if tile_m % (num_mma_warps * 16) != 0:
+            return False
+        hdim_multiple_of = 16
+        tile_hdim = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
+        tile_hdimv = int(math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of)
+        elem_bytes = dtype.width // 8
+        # SMEM: mbarriers + sQ (1 stage) + sK (kv_stages) + sV (kv_stages)
+        smem_q = tile_m * tile_hdim * elem_bytes
+        smem_k = tile_n * tile_hdim * elem_bytes * kv_stages
+        smem_v = tile_n * tile_hdimv * elem_bytes * kv_stages
+        # mbarrier arrays: q(1*2) + k(kv_stages*2) + v(kv_stages*2) Int64 entries
+        smem_mbar = (1 * 2 + kv_stages * 2 * 2) * 8
+        smem_mbar_region = ((smem_mbar + 1023) // 1024) * 1024
+        smem_total = smem_mbar_region + smem_q + smem_k + smem_v
+        # Round up for alignment padding
+        smem_total += 2 * 1024  # conservative padding for Align[..., 1024]
+        smem_capacity = utils_basic.get_smem_capacity_in_bytes("sm_120")
+        if smem_total > smem_capacity:
+            return False
+        return True
+
+    def _get_smem_layout_atom(self):
+        """TMA-compatible SMEM layout atoms with Swizzle(B, 4, 3)."""
+        sQ_layout_atom = get_smem_layout_atom_tma(self.dtype, self.tile_hdim)
+        sK_layout_atom = get_smem_layout_atom_tma(self.dtype, self.tile_hdim)
+        sV_layout_atom = get_smem_layout_atom_tma(self.dtype, self.tile_hdimv)
+        sO_layout_atom = get_smem_layout_atom_tma(self.dtype, self.tile_hdimv)
+        sP_layout_atom = None
+        return sQ_layout_atom, sK_layout_atom, sV_layout_atom, sO_layout_atom, sP_layout_atom
+
+    def _get_tiled_mma(self):
+        """SM80-compatible MMA for QK and PV GEMMs, using only MMA warps."""
+        tiled_mma_qk = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self.dtype, Float32, (16, 8, 16)),
+            (self.num_mma_warps, 1, 1),
+            permutation_mnk=(self.num_mma_warps * 16, 16, 16),
+        )
+        tiled_mma_pv = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self.dtype, Float32, (16, 8, 16)),
+            (self.num_mma_warps, 1, 1),
+            permutation_mnk=(self.num_mma_warps * 16, 16, 16),
+        )
+        return tiled_mma_qk, tiled_mma_pv
+
+    def _get_shared_storage_cls(self):
+        """Shared storage with mbarrier arrays for TMA pipelines."""
+        sQ_struct = cute.struct.Align[
+            cute.struct.MemRange[self.dtype, cute.cosize(self.sQ_layout)], 1024
+        ]
+        sK_struct = cute.struct.Align[
+            cute.struct.MemRange[self.dtype, cute.cosize(self.sK_layout)], 1024
+        ]
+        sV_struct = cute.struct.Align[
+            cute.struct.MemRange[self.dtype, cute.cosize(self.sV_layout)], 1024
+        ]
+        # mbarrier arrays: Q uses 1 stage, K and V use kv_stages stages
+        mbar_ptr_Q_struct = cute.struct.MemRange[cutlass.Int64, 1 * 2]
+        mbar_ptr_K_struct = cute.struct.MemRange[cutlass.Int64, self.kv_stages * 2]
+        mbar_ptr_V_struct = cute.struct.MemRange[cutlass.Int64, self.kv_stages * 2]
+
+        @cute.struct
+        class SharedStorage:
+            q_mbar_ptr: mbar_ptr_Q_struct
+            k_mbar_ptr: mbar_ptr_K_struct
+            v_mbar_ptr: mbar_ptr_V_struct
+            sQ: sQ_struct
+            sK: sK_struct
+            sV: sV_struct
+
+        return SharedStorage
+
+    @cute.jit
+    def apply_score_mod(
+        self,
+        thr_mma_qk,
+        batch_idx,
+        head_idx,
+        m_block,
+        acc_S,
+        n_block,
+        seqlen,
+        softmax_scale,
+        aux_tensors=None,
+        fastdiv_mods=None,
+    ):
+        """Apply score_mod to attention scores."""
+        cS = cute.make_identity_tensor((self.tile_m, self.tile_n))
+        cS = cute.domain_offset((m_block * self.tile_m, n_block * self.tile_n), cS)
+        tScS = thr_mma_qk.partition_C(cS)
+        apply_score_mod_inner(
+            acc_S,
+            tScS,
+            self.score_mod,
+            batch_idx,
+            head_idx,
+            softmax_scale,
+            self.score_vec_size,
+            self.qk_acc_dtype,
+            aux_tensors,
+            fastdiv_mods,
+            seqlen_info=seqlen,
+            constant_q_idx=None,
+            qhead_per_kvhead=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+
+    def _setup_attributes_tma(self):
+        """Setup only the attributes needed for TMA kernel (skip CpAsync Q/K/V copies).
+
+        TMA uses hardware-managed bulk copies instead of CpAsync, so we only need:
+          - SMEM layouts (sQ_layout, sK_layout, sV_layout, sO_layout)
+          - gmem_tiled_copy_O (for epilogue O store via SMEM)
+        """
+        sQ_layout_atom, sK_layout_atom, sV_layout_atom, sO_layout_atom, sP_layout_atom = (
+            self._get_smem_layout_atom()
+        )
+        # sQ has a trailing 1-stage dim for TMA partition compatibility
+        self.sQ_layout = cute.tile_to_shape(
+            sQ_layout_atom,
+            (self.tile_m, self.tile_hdim, 1),
+            (0, 1, 2),
+        )
+        self.sK_layout = cute.tile_to_shape(
+            sK_layout_atom,
+            (self.tile_n, self.tile_hdim, self.num_stages),
+            (0, 1, 2),
+        )
+        self.sV_layout = cute.tile_to_shape(
+            sV_layout_atom,
+            (self.tile_n, self.tile_hdimv, self.num_stages),
+            (0, 1, 2),
+        )
+        self.sO_layout = cute.tile_to_shape(
+            sO_layout_atom,
+            (self.tile_m, self.tile_hdimv),
+            (0, 1),
+        )
+        self.sP_layout = None
+
+        # Only create O store copy (MMA warps handle epilogue)
+        universal_copy_bits = 128
+        o_copy_elems = universal_copy_bits // self.dtype.width
+        atom_universal_copy_O = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        tO_shape_dim_1 = sO_layout_atom.outer.shape[1] // o_copy_elems
+        tO_layout = cute.make_ordered_layout(
+            (self.num_epilogue_threads // tO_shape_dim_1, tO_shape_dim_1),
+            order=(1, 0),
+        )
+        vO_layout = cute.make_layout((1, o_copy_elems))
+        self.gmem_tiled_copy_O = cute.make_tiled_copy_tv(atom_universal_copy_O, tO_layout, vO_layout)
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        softmax_scale: Float32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        mPageTable: Optional[cute.Tensor] = None,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+        learnable_sink: Optional[cute.Tensor] = None,
+        blocksparse_tensors=None,
+        aux_tensors=None,
+        # Always keep stream as the last parameter (matches base
+        # FlashAttentionForwardSm80.__call__ convention; cute.compile
+        # binds arguments positionally against compile_args, which ends
+        # with current_stream).
+        stream: cuda.CUstream = None,
+    ):
+        """Configures and launches the TMA SM120 flash attention kernel.
+
+        mQ/mK/mV/mO layout: (batch_size, seqlen, num_head, head_dim)
+        """
+        assert learnable_sink is None, "Learnable sink is not supported in this kernel"
+        assert mPageTable is None, "Paged KV not supported with TMA kernel (use CpAsync fallback)"
+        self._check_type(
+            *(t.element_type if t is not None else None
+              for t in (mQ, mK, mV, mO, mLSE, mCuSeqlensQ, mCuSeqlensK, mSeqUsedQ, mSeqUsedK))
+        )
+        self.o_dtype = mO.element_type
+
+        tiled_mma_qk, tiled_mma_pv = self._get_tiled_mma()
+        self.num_mma_threads = tiled_mma_qk.size  # num_mma_warps * 32
+        self.num_producer_threads = 32  # DMA warp
+        self.num_Q_load_threads = self.num_mma_threads
+        self.num_epilogue_threads = self.num_mma_threads
+
+        self._setup_attributes_tma()
+        SharedStorage = self._get_shared_storage_cls()
+
+        mQ, mK, mV, mO = [assume_tensor_aligned(t) for t in (mQ, mK, mV, mO)]
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Layout transpose for TMA: (batch, seq, head, dim) → (seq, dim, head, batch)
+        # TMA tiles the leading 2 modes (seq, dim); head and batch are coordinate modes
+        # For varlen: (total, head, dim) → (total, dim, head)
+        # ///////////////////////////////////////////////////////////////////////////////
+        Q_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
+        KV_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensK is None) else [0, 2, 1]
+        mQ_t = layout_utils.select(mQ, Q_layout_transpose)
+        mK_t = layout_utils.select(mK, KV_layout_transpose)
+        mV_t = layout_utils.select(mV, KV_layout_transpose)
+
+        # O and LSE layout transpose (no split-KV in TMA kernel)
+        O_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
+        LSE_layout_transpose = [2, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 0]
+        num_splits = Int32(1)
+        mO_t = layout_utils.select(mO, O_layout_transpose)
+        mLSE_t = layout_utils.select(mLSE, LSE_layout_transpose) if const_expr(mLSE is not None) else None
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # TMA descriptors
+        # ///////////////////////////////////////////////////////////////////////////////
+        sQ_layout_one_stage = cute.slice_(self.sQ_layout, (None, None, 0))  # sQ is (m, d, 1)
+        sK_layout_one_stage = cute.slice_(self.sK_layout, (None, None, 0))
+        sV_layout_one_stage = cute.slice_(self.sV_layout, (None, None, 0))
+
+        tma_op = cpasync.CopyBulkTensorTileG2SOp()
+
+        # For non-varlen: mQ_t is (seq, dim, head, batch), tile (seq, dim)
+        # For varlen: mQ_t is (total, dim, head), tile (total, dim)
+        tma_atom_q, tma_tensor_q = cpasync.make_tiled_tma_atom(
+            tma_op, mQ_t, sQ_layout_one_stage,
+            (self.tile_m, self.tile_hdim), num_multicast=1,
+        )
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            tma_op, mK_t, sK_layout_one_stage,
+            (self.tile_n, self.tile_hdim), num_multicast=1,
+        )
+        tma_atom_v, tma_tensor_v = cpasync.make_tiled_tma_atom(
+            tma_op, mV_t, sV_layout_one_stage,
+            (self.tile_n, self.tile_hdimv), num_multicast=1,
+        )
+
+        # TMA transfer sizes (bytes per load)
+        q_copy_bytes = cute.size_in_bytes(self.dtype, sQ_layout_one_stage)
+        kv_copy_bytes = cute.size_in_bytes(self.dtype, sK_layout_one_stage)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Tile scheduler
+        # ///////////////////////////////////////////////////////////////////////////////
+        if const_expr(mCuSeqlensQ is not None or mSeqUsedQ is not None):
+            TileScheduler = SingleTileVarlenScheduler
+        else:
+            TileScheduler = SingleTileScheduler
+        num_batch = (
+            mCuSeqlensQ.shape[0] - 1
+            if const_expr(mCuSeqlensQ is not None)
+            else mQ_t.shape[3]
+        )
+        tile_sched_args = TileSchedulerArguments(
+            num_block=cute.ceil_div(mQ_t.shape[0], self.tile_m),
+            num_head=cute.size(mQ_t.shape[2]),
+            num_batch=num_batch,
+            num_splits=num_splits,
+            seqlen_k=0,
+            headdim=mQ_t.shape[1],
+            headdim_v=mV_t.shape[1],
+            total_q=cute.size(mQ_t.shape[0])
+            if const_expr(mCuSeqlensQ is not None)
+            else cute.size(mQ_t.shape[0]) * num_batch,
+            tile_shape_mn=(self.tile_m, self.tile_n),
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            mCuSeqlensQ=mCuSeqlensQ,
+            mSeqUsedQ=mSeqUsedQ,
+            element_size=self.dtype.width // 8,
+            is_persistent=False,
+            lpt=self.is_causal or self.is_local,
+            is_split_kv=False,
+        )
+        tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
+        grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
+        softmax_scale_log2, softmax_scale_adj = utils.compute_softmax_scale_log2(softmax_scale, self.score_mod)
+        fastdiv_mods = utils.compute_fastdiv_mods(mQ_t, mK_t, self.qhead_per_kvhead, self.pack_gqa, aux_tensors.tensors if aux_tensors is not None else None)
+
+        self.kernel(
+            tma_atom_q, tma_tensor_q,
+            tma_atom_k, tma_tensor_k,
+            tma_atom_v, tma_tensor_v,
+            mQ_t,
+            mK_t,
+            mV_t,
+            mO_t,
+            mLSE_t,
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            mSeqUsedQ,
+            mSeqUsedK,
+            softmax_scale_log2,
+            softmax_scale_adj,
+            window_size_left,
+            window_size_right,
+            q_copy_bytes,
+            kv_copy_bytes,
+            self.sQ_layout,
+            self.sK_layout,
+            self.sV_layout,
+            self.sO_layout,
+            self.gmem_tiled_copy_O,
+            tiled_mma_qk,
+            tiled_mma_pv,
+            SharedStorage,
+            tile_sched_params,
+            TileScheduler,
+            num_splits,
+            aux_tensors,
+            fastdiv_mods,
+        ).launch(
+            grid=grid_dim,
+            block=[self.num_threads, 1, 1],
+            cluster=[1, 1, 1],
+            smem=SharedStorage.size_in_bytes(),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tma_atom_q: cute.CopyAtom,
+        mQ_tma: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        mK_tma: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        mV_tma: cute.Tensor,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        mCuSeqlensQ: Optional[cute.Tensor],
+        mCuSeqlensK: Optional[cute.Tensor],
+        mSeqUsedQ: Optional[cute.Tensor],
+        mSeqUsedK: Optional[cute.Tensor],
+        softmax_scale_log2: Float32,
+        softmax_scale: Optional[Float32],
+        window_size_left: Optional[Int32],
+        window_size_right: Optional[Int32],
+        q_copy_bytes: cutlass.Constexpr,
+        kv_copy_bytes: cutlass.Constexpr,
+        sQ_layout: cute.ComposedLayout,
+        sK_layout: cute.ComposedLayout,
+        sV_layout: cute.ComposedLayout,
+        sO_layout: cute.ComposedLayout,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tiled_mma_qk: cute.TiledMma,
+        tiled_mma_pv: cute.TiledMma,
+        SharedStorage: cutlass.Constexpr,
+        tile_sched_params,
+        TileScheduler: cutlass.Constexpr[Callable],
+        num_splits: Int32,
+        aux_tensors=None,
+        fastdiv_mods=None,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Tile scheduler: determine m_block, head, batch, split
+        # ///////////////////////////////////////////////////////////////////////////////
+        tile_scheduler = TileScheduler.create(tile_sched_params)
+        work_tile = tile_scheduler.initial_work_tile_info()
+        m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+
+        block_info = BlockInfo(
+            self.tile_m,
+            self.tile_n,
+            self.is_causal,
+            self.is_local,
+            False,  # is_split_kv: not supported in TMA kernel yet
+            window_size_left,
+            window_size_right,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+        seqlen = SeqlenInfoQK.create(
+            batch_idx=batch_idx,
+            seqlen_q_static=mQ.shape[0],
+            seqlen_k_static=mK.shape[0],
+            mCuSeqlensQ=mCuSeqlensQ,
+            mCuSeqlensK=mCuSeqlensK,
+            mSeqUsedQ=mSeqUsedQ,
+            mSeqUsedK=mSeqUsedK,
+        )
+        n_block_min, n_block_max = block_info.get_n_block_min_max(
+            seqlen, m_block, split_idx, num_splits
+        )
+        n_block = cutlass.max(n_block_max - 1, 0)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Allocate SMEM and create tensors
+        # ///////////////////////////////////////////////////////////////////////////////
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
+        sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
+        sV = storage.sV.get_tensor(sV_layout.outer, swizzle=sV_layout.inner)
+
+        # Transpose view of V for PV GEMM: (head_dim_v, tile_n, kv_stages)
+        sVt = layout_utils.transpose_view(sV)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # TMA partition: global → smem tile mapping
+        # ///////////////////////////////////////////////////////////////////////////////
+        # For non-varlen: mQ_tma is (seq, dim, head, batch), tile (seq, dim)
+        # For varlen: mQ_tma is (total, dim, head), tile (total, dim)
+        if const_expr(mCuSeqlensQ is None):
+            gQ = cute.local_tile(
+                mQ_tma,
+                (self.tile_m, self.tile_hdim),
+                (None, 0, None, None),
+            )
+        else:
+            gQ = cute.local_tile(
+                mQ_tma,
+                (self.tile_m, self.tile_hdim),
+                (None, 0, None),
+            )
+        tQsQ, tQgQ = cpasync.tma_partition(
+            tma_atom_q, 0, cute.make_layout(1),
+            cute.group_modes(sQ, 0, 2),
+            cute.group_modes(gQ, 0, 2),
+        )
+
+        if const_expr(mCuSeqlensK is None):
+            gK = cute.local_tile(
+                mK_tma,
+                (self.tile_n, self.tile_hdim),
+                (None, 0, None, None),
+            )
+            gV = cute.local_tile(
+                mV_tma,
+                (self.tile_n, self.tile_hdimv),
+                (None, 0, None, None),
+            )
+        else:
+            gK = cute.local_tile(
+                mK_tma,
+                (self.tile_n, self.tile_hdim),
+                (None, 0, None),
+            )
+            gV = cute.local_tile(
+                mV_tma,
+                (self.tile_n, self.tile_hdimv),
+                (None, 0, None),
+            )
+        tKsK, tKgK = cpasync.tma_partition(
+            tma_atom_k, 0, cute.make_layout(1),
+            cute.group_modes(sK, 0, 2),
+            cute.group_modes(gK, 0, 2),
+        )
+        tVsV, tVgV = cpasync.tma_partition(
+            tma_atom_v, 0, cute.make_layout(1),
+            cute.group_modes(sV, 0, 2),
+            cute.group_modes(gV, 0, 2),
+        )
+
+        # Select this CTA's head, batch, and offset coordinates
+        num_head_kv = head_idx // self.qhead_per_kvhead
+        if const_expr(mCuSeqlensQ is None):
+            tQgQ_block = tQgQ[(None, m_block, head_idx, batch_idx)]
+        else:
+            # For varlen, compute the Q offset and use it directly
+            tQgQ_block = tQgQ[(None, m_block + seqlen.offset_q // self.tile_m, head_idx)]
+        if const_expr(mCuSeqlensK is None):
+            tKgK_block = tKgK[(None, None, num_head_kv, batch_idx)]
+            tVgV_block = tVgV[(None, None, num_head_kv, batch_idx)]
+        else:
+            tKgK_block = tKgK[(None, None, num_head_kv)]
+            tVgV_block = tVgV[(None, None, num_head_kv)]
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Init pipelines
+        # ///////////////////////////////////////////////////////////////////////////////
+        q_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.num_mma_warps
+            ),
+            tx_count=q_copy_bytes,
+            barrier_storage=storage.q_mbar_ptr.data_ptr(),
+        )
+        k_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.kv_stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.num_mma_warps
+            ),
+            tx_count=kv_copy_bytes,
+            barrier_storage=storage.k_mbar_ptr.data_ptr(),
+        )
+        v_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.kv_stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.num_mma_warps
+            ),
+            tx_count=kv_copy_bytes,
+            barrier_storage=storage.v_mbar_ptr.data_ptr(),
+        )
+
+        pipeline.sync(barrier_id=0)
+
+        # Prefetch TMA descriptors
+        if warp_idx == 0:
+            cpasync.prefetch_descriptor(tma_atom_q)
+            cpasync.prefetch_descriptor(tma_atom_k)
+            cpasync.prefetch_descriptor(tma_atom_v)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # MMA partition setup (same SM80 mma.sync as CpAsync version)
+        # ///////////////////////////////////////////////////////////////////////////////
+        thr_mma_qk = tiled_mma_qk.get_slice(tidx)
+        thr_mma_pv = tiled_mma_pv.get_slice(tidx)
+        sQ_one = sQ[None, None, 0]  # 2D view of stage 0
+        tSrQ = thr_mma_qk.make_fragment_A(thr_mma_qk.partition_A(sQ_one))
+        tSrK = thr_mma_qk.make_fragment_B(thr_mma_qk.partition_B(sK[None, None, 0]))
+        tOrVt = thr_mma_pv.make_fragment_B(thr_mma_pv.partition_B(sVt[None, None, 0]))
+        acc_shape_O = thr_mma_pv.partition_shape_C((self.tile_m, self.tile_hdimv))
+        acc_O = cute.make_fragment(acc_shape_O, Float32)
+        acc_O.fill(0.0)
+
+        # LdMatrix atoms: shared → register
+        smem_copy_atom_QK = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+            self.dtype,
+        )
+        smem_copy_atom_V = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4),
+            self.dtype,
+        )
+        smem_thr_copy_Q = utils.make_tiled_copy_A(smem_copy_atom_QK, tiled_mma_qk).get_slice(tidx)
+        smem_thr_copy_K = utils.make_tiled_copy_B(smem_copy_atom_QK, tiled_mma_qk).get_slice(tidx)
+        smem_thr_copy_V = utils.make_tiled_copy_B(smem_copy_atom_V, tiled_mma_pv).get_slice(tidx)
+
+        tSsQ = smem_thr_copy_Q.partition_S(sQ_one)
+        tSsK = smem_thr_copy_K.partition_S(sK)
+        tOsVt = smem_thr_copy_V.partition_S(sVt)
+
+        # Softmax state
+        softmax = Softmax.create(
+            softmax_scale_log2,
+            num_rows=acc_O.shape[0][0] * acc_O.shape[1],
+            softmax_scale=softmax_scale,
+        )
+        softmax.reset()
+
+        # Pipeline states
+        q_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, 1
+        )
+        k_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.kv_stages
+        )
+        v_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.kv_stages
+        )
+        k_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.kv_stages
+        )
+        v_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.kv_stages
+        )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Warp specialization
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx < self.num_mma_warps:
+            # ===== MMA warps (consumer) =====
+            cute.arch.setmaxregister_increase(232)
+
+            if n_block_max > n_block_min:
+                # Wait for Q to be loaded
+                q_pipeline.consumer_wait(
+                    pipeline.make_pipeline_state(
+                        pipeline.PipelineUserType.Consumer, 1
+                    )
+                )
+
+                # Attention mask
+                mask = AttentionMask(
+                    self.tile_m,
+                    self.tile_n,
+                    seqlen,
+                    window_size_left,
+                    window_size_right,
+                    self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+                )
+                mask_fn = partial(
+                    mask.apply_mask,
+                    batch_idx=batch_idx,
+                    head_idx=head_idx,
+                    m_block=m_block,
+                    thr_mma=thr_mma_qk,
+                    mask_causal=self.is_causal,
+                    mask_local=self.is_local,
+                    aux_data=aux_tensors if aux_tensors is not None else AuxData(),
+                    fastdiv_mods=fastdiv_mods if const_expr(self.mask_mod is not None) else None,
+                )
+
+                # Main attention loop: all pipeline operations inlined here
+                # (not delegated to a separate @cute.jit method) to avoid CuTe DSL
+                # compiler hangs when pipeline states flow through method boundaries.
+                # Matches the standalone CUTLASS kernel's pattern (flash_attention_v2.py:1348).
+                for n_tile in range(0, n_block_max - n_block_min, 1, unroll=1):
+                    cur_n_block = n_block_max - n_tile - 1
+
+                    # --- Wait for K, compute S = Q * K^T ---
+                    k_pipeline.consumer_wait(k_consumer_state)
+                    k_stage = k_consumer_state.index
+
+                    acc_shape_S = thr_mma_qk.partition_shape_C((self.tile_m, self.tile_n))
+                    acc_S = cute.make_fragment(acc_shape_S, Float32)
+                    acc_S.fill(0.0)
+
+                    sm80_utils.gemm(
+                        thr_mma_qk, acc_S, tSrQ, tSrK,
+                        tSsQ, tSsK[None, None, None, k_stage],
+                        smem_thr_copy_Q, smem_thr_copy_K, A_in_regs=False,
+                    )
+
+                    k_pipeline.consumer_release(k_consumer_state)
+                    k_consumer_state.advance()
+
+                    # Apply score_mod if present
+                    if const_expr(self.score_mod is not None):
+                        self.apply_score_mod(
+                            thr_mma_qk, batch_idx, head_idx, m_block,
+                            acc_S, cur_n_block, seqlen,
+                            softmax_scale=softmax.softmax_scale,
+                            aux_tensors=aux_tensors, fastdiv_mods=fastdiv_mods,
+                        )
+
+                    # Apply mask (always check seqlen; causal handled by AttentionMask)
+                    mask_fn(acc_S, n_block=cur_n_block, mask_mod=self.mask_mod, mask_seqlen=True)
+
+                    # Online softmax (is_first=False: softmax.reset() pre-initialized
+                    # row_max=-inf and row_sum=0, which gives correct results for the
+                    # first iteration without needing a compile-time is_first flag)
+                    row_scale = softmax.online_softmax(acc_S, is_first=False, check_inf=True)
+                    softmax.rescale_O(acc_O, row_scale)
+
+                    # Cast P to dtype for PV GEMM
+                    rP = cute.make_fragment_like(acc_S, self.dtype)
+                    rP.store(acc_S.load().to(self.dtype))
+                    tOrP = layout_utils.reshape_acc_to_frgA(rP)
+
+                    # --- Wait for V, compute O += P * V ---
+                    v_pipeline.consumer_wait(v_consumer_state)
+                    v_stage = v_consumer_state.index
+
+                    sm80_utils.gemm_rs(
+                        thr_mma_pv, acc_O, tOrP, tOrVt,
+                        tOsVt[None, None, None, v_stage], smem_thr_copy_V,
+                    )
+
+                    v_pipeline.consumer_release(v_consumer_state)
+                    v_consumer_state.advance()
+
+                # Finalize softmax
+                row_scale = softmax.finalize()
+                softmax.rescale_O(acc_O, row_scale)
+
+            # ///////////////////////////////////////////////////////////////////////////////
+            # Epilogue: normalize and store O (reuse base class epilogue)
+            # ///////////////////////////////////////////////////////////////////////////////
+            # sQ.iterator already carries the swizzle, so use sO_layout.outer (no swizzle)
+            sO = cute.make_tensor(sQ.iterator, sO_layout.outer)
+            self.epilogue(
+                acc_O,
+                softmax.row_sum,
+                mO,
+                mLSE,
+                sO,
+                seqlen,
+                gmem_tiled_copy_O,
+                None,  # no TMA for O
+                tiled_mma_pv,
+                tidx,
+                m_block,
+                head_idx,
+                batch_idx,
+            )
+
+        elif warp_idx == self.num_mma_warps:
+            # ===== DMA warp (producer) =====
+            cute.arch.setmaxregister_decrease(40)
+
+            if n_block_max > n_block_min:
+                # Load Q (once, single stage)
+                q_pipeline.producer_acquire(q_producer_state)
+                cute.copy(
+                    tma_atom_q, tQgQ_block,
+                    tQsQ[(None, q_producer_state.index)],
+                    tma_bar_ptr=q_pipeline.producer_get_barrier(q_producer_state),
+                )
+                q_pipeline.producer_commit(q_producer_state)
+
+                # Load KV tiles (high to low for causal, matching consumer order)
+                for n_tile in cutlass.range(n_block_max - n_block_min, unroll=1):
+                    cur_n_block = n_block_max - n_tile - 1
+
+                    # Compute the TMA source index for K/V
+                    if const_expr(mCuSeqlensK is not None):
+                        kv_tma_idx = cur_n_block + seqlen.offset_k // self.tile_n
+                    else:
+                        kv_tma_idx = cur_n_block
+
+                    # Load K
+                    k_pipeline.producer_acquire(k_producer_state)
+                    cute.copy(
+                        tma_atom_k,
+                        tKgK_block[(None, kv_tma_idx)],
+                        tKsK[(None, k_producer_state.index)],
+                        tma_bar_ptr=k_pipeline.producer_get_barrier(k_producer_state),
+                    )
+                    k_pipeline.producer_commit(k_producer_state)
+                    k_producer_state.advance()
+
+                    # Load V
+                    v_pipeline.producer_acquire(v_producer_state)
+                    cute.copy(
+                        tma_atom_v,
+                        tVgV_block[(None, kv_tma_idx)],
+                        tVsV[(None, v_producer_state.index)],
+                        tma_bar_ptr=v_pipeline.producer_get_barrier(v_producer_state),
+                    )
+                    v_pipeline.producer_commit(v_producer_state)
+                    v_producer_state.advance()
+
+                # Signal pipeline tail
+                k_pipeline.producer_tail(k_producer_state)
+                v_pipeline.producer_tail(v_producer_state)
+
+    @cute.jit
+    def mma_one_n_block(
+        self,
+        n_block: Int32,
+        k_pipeline,
+        k_consumer_state,
+        v_pipeline,
+        v_consumer_state,
+        mma_params: SimpleNamespace,
+        smem_copy_params: SimpleNamespace,
+        softmax: Softmax,
+        seqlen: SeqlenInfoQK,
+        batch_idx: Int32,
+        head_idx: Int32,
+        m_block: Int32,
+        mask_fn: Optional[Callable] = None,
+        is_first_n_block: cutlass.Constexpr = False,
+        aux_tensors=None,
+        fastdiv_mods=None,
+    ):
+        """Consumer: compute one n_block of S and O with TMA pipeline synchronization."""
+
+        # --- Wait for K, compute S = Q * K^T ---
+        k_pipeline.consumer_wait(k_consumer_state)
+        k_stage = k_consumer_state.index
+
+        acc_shape_S = mma_params.thr_mma_qk.partition_shape_C((self.tile_m, self.tile_n))
+        acc_S = cute.make_fragment(acc_shape_S, Float32)
+        acc_S.fill(0.0)
+
+        # QK GEMM using SM80 MMA with register pipeline
+        sm80_utils.gemm(
+            mma_params.thr_mma_qk,
+            acc_S,
+            mma_params.tSrQ,
+            mma_params.tSrK,
+            smem_copy_params.tSsQ,
+            smem_copy_params.tSsK[None, None, None, k_stage],
+            smem_copy_params.smem_thr_copy_Q,
+            smem_copy_params.smem_thr_copy_K,
+            A_in_regs=False,
+        )
+
+        k_pipeline.consumer_release(k_consumer_state)
+        k_consumer_state.advance()
+
+        # Apply score_mod if present
+        if const_expr(self.score_mod is not None):
+            self.apply_score_mod(
+                mma_params.thr_mma_qk,
+                batch_idx,
+                head_idx,
+                m_block,
+                acc_S,
+                n_block,
+                seqlen,
+                softmax_scale=softmax.softmax_scale,
+                aux_tensors=aux_tensors,
+                fastdiv_mods=fastdiv_mods,
+            )
+
+        # Apply mask
+        if const_expr(mask_fn is not None):
+            mask_fn(acc_S, n_block=n_block)
+
+        # Online softmax
+        row_scale = softmax.online_softmax(acc_S, is_first=is_first_n_block, check_inf=True)
+        softmax.rescale_O(mma_params.acc_O, row_scale)
+
+        # Cast P to dtype for PV GEMM
+        rP = cute.make_fragment_like(acc_S, self.dtype)
+        rP.store(acc_S.load().to(self.dtype))
+        tOrP = layout_utils.reshape_acc_to_frgA(rP)
+
+        # --- Wait for V, compute O += P * V ---
+        v_pipeline.consumer_wait(v_consumer_state)
+        v_stage = v_consumer_state.index
+
+        # PV GEMM using SM80 MMA
+        sm80_utils.gemm_rs(
+            mma_params.thr_mma_pv,
+            mma_params.acc_O,
+            tOrP,
+            mma_params.tOrVt,
+            smem_copy_params.tOsVt[None, None, None, v_stage],
+            smem_copy_params.smem_thr_copy_V,
+        )
+
+        v_pipeline.consumer_release(v_consumer_state)
+        v_consumer_state.advance()

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -533,13 +533,14 @@ def _flash_attn_fwd(
     fwd_cfg = FwdConfig(128, 128, True, True)  # default
     if tile_mn is None:
         if arch // 10 == 12:
-            # SM120 tile sizes tuned for 99 KB SMEM capacity:
-            # D<=64:  128x128 → 48 KB (good occupancy)
-            # D>64:   128x64  → 64 KB (128x128 would use 96 KB, hurting occupancy)
+            # SM120 tile sizes, autotuned on RTX PRO 6000 (CpAsync num_stages=1 path).
+            # hd128: 128x128 fits 96 KB (Q+K+V single-stage), beats 128x64 by 10-25%.
+            # hd<=64: 128x256 fits ~80 KB and beats 128x128 by ~10% at seqlen>=2048
+            # (more KV per tile amortizes softmax). Both beat sdpa-flash on this chip.
             if head_dim <= 64:
-                fwd_cfg = FwdConfig(128, 128, True, True)
+                fwd_cfg = FwdConfig(128, 256, True, True)
             else:
-                fwd_cfg = FwdConfig(128, 64, True, True)
+                fwd_cfg = FwdConfig(128, 128, True, True)
         elif arch // 10 == 8:
             fwd_cfg = FwdConfig(128, 64, True, True)  # SM80, should tune
         elif arch // 10 == 9:
@@ -960,9 +961,18 @@ def _flash_attn_fwd(
             # fallback handles GQA correctly and is at perf parity on sm_120.
             is_varlen = cu_seqlens_q is not None or cu_seqlens_k is not None
             use_tma_sm120 = (page_table is None and not is_varlen and not pack_gqa)
+            # Autotune knobs (temporary; env-overridable for sweeps).
+            _sm120_nmw = int(os.environ.get("FA_SM120_MMA_WARPS", "8"))
+            _sm120_kvs = int(os.environ.get("FA_SM120_KV_STAGES", "2"))
+            _sm120_tm = os.environ.get("FA_SM120_TILE_M")
+            _sm120_tn = os.environ.get("FA_SM120_TILE_N")
+            if _sm120_tm is not None:
+                tile_m = int(_sm120_tm)
+            if _sm120_tn is not None:
+                tile_n = int(_sm120_tn)
             if use_tma_sm120 and FlashAttentionForwardSm120Tma.can_implement(
                 dtype, head_dim, head_dim_v, tile_m, tile_n,
-                num_mma_warps=8, kv_stages=2, is_causal=causal,
+                num_mma_warps=_sm120_nmw, kv_stages=_sm120_kvs, is_causal=causal,
             ):
                 fa_fwd = FlashAttentionForwardSm120Tma(
                     dtype,
@@ -974,8 +984,8 @@ def _flash_attn_fwd(
                     pack_gqa=pack_gqa,
                     tile_m=tile_m,
                     tile_n=tile_n,
-                    num_mma_warps=8,
-                    kv_stages=2,
+                    num_mma_warps=_sm120_nmw,
+                    kv_stages=_sm120_kvs,
                     score_mod=score_mod,
                     mask_mod=mask_mod,
                     has_aux_tensors=aux_tensors is not None,

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -460,12 +460,13 @@ def _flash_attn_fwd(
     qhead_per_kvhead = num_head // num_head_kv
     if pack_gqa is None:
         pack_gqa = qhead_per_kvhead > 1
-        # SM120 (Blackwell GeForce / RTX PRO / DGX Spark): the pack_gqa packed-coordinate
-        # O-store path is not functional on this arch (crd2idx on the (h_idx, m_idx) packed
-        # gmem tensor). GQA is handled correctly via the standard per-head path, which is at
-        # perf parity on sm_120, so disable pack_gqa by default here.
-        if pack_gqa and torch.cuda.get_device_capability(q.device)[0] == 12:
-            pack_gqa = False
+    # SM120 (Blackwell GeForce / RTX PRO / DGX Spark): the pack_gqa packed-coordinate
+    # O-store path is not functional on this arch (crd2idx fails on the (h_idx, m_idx)
+    # packed gmem tensor in pack_gqa.store_O). GQA is handled correctly via the standard
+    # per-head path, which is at perf parity on sm_120, so force-disable pack_gqa here
+    # regardless of how it was requested. Numerics are identical.
+    if pack_gqa and torch.cuda.get_device_capability(v.device)[0] == 12:
+        pack_gqa = False
 
     is_fp8 = v.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
     requires_grad = any(t is not None and t.requires_grad for t in [q, k, v, qv])
@@ -588,6 +589,12 @@ def _flash_attn_fwd(
             num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
         else:
             num_splits = 1
+
+    # SM120 (Blackwell GeForce / RTX PRO / DGX Spark) does not have the SplitKV
+    # forward + combine path wired up; force a single split. The full-KV kernel is
+    # correct and is the only supported path on this arch.
+    if arch // 10 == 12 and num_splits != 1:
+        num_splits = 1
 
     is_split_kv = num_splits > 1
     if is_split_kv:

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -330,6 +330,9 @@ def _flash_attn_fwd(
     k_descale: Optional[torch.Tensor] = None,
     v_descale: Optional[torch.Tensor] = None,
     gather_kv_indices: Optional[torch.Tensor] = None,
+    dropout_p: float = 0.0,
+    dropout_seed: Optional[int] = None,
+    dropout_offset: int = 0,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Forward pass for FlashAttention.
 
@@ -531,6 +534,7 @@ def _flash_attn_fwd(
         num_threads = 256
 
     fwd_cfg = FwdConfig(128, 128, True, True)  # default
+    _sm120_is_tma = False  # set True only when the sm120 TMA forward kernel is selected
     if tile_mn is None:
         if arch // 10 == 12:
             # SM120 tile sizes, autotuned on RTX PRO 6000 (CpAsync num_stages=1 path).
@@ -759,6 +763,7 @@ def _flash_attn_fwd(
         row_max is not None,
         gather_kv_length,
         sparse_kv,
+        dropout_p > 0.0,
         disable_sparse_kv_bitmask,
         fa_logging.get_fa_log_level(),
     )
@@ -960,7 +965,7 @@ def _flash_attn_fwd(
             # pack_gqa O-store is not yet supported in the TMA epilogue; the CpAsync
             # fallback handles GQA correctly and is at perf parity on sm_120.
             is_varlen = cu_seqlens_q is not None or cu_seqlens_k is not None
-            use_tma_sm120 = (page_table is None and not is_varlen and not pack_gqa)
+            use_tma_sm120 = (page_table is None and not is_varlen and not pack_gqa and dropout_p == 0.0)
             # Autotune knobs (temporary; env-overridable for sweeps).
             _sm120_nmw = int(os.environ.get("FA_SM120_MMA_WARPS", "8"))
             _sm120_kvs = int(os.environ.get("FA_SM120_KV_STAGES", "2"))
@@ -974,6 +979,7 @@ def _flash_attn_fwd(
                 dtype, head_dim, head_dim_v, tile_m, tile_n,
                 num_mma_warps=_sm120_nmw, kv_stages=_sm120_kvs, is_causal=causal,
             ):
+                _sm120_is_tma = True
                 fa_fwd = FlashAttentionForwardSm120Tma(
                     dtype,
                     head_dim,
@@ -1007,6 +1013,7 @@ def _flash_attn_fwd(
                     score_mod=score_mod,
                     mask_mod=mask_mod,
                     has_aux_tensors=aux_tensors is not None,
+                    dropout_p=dropout_p,
                 )
         else:
             raise ValueError(
@@ -1060,6 +1067,20 @@ def _flash_attn_fwd(
                 sparse_tensors,
                 AuxData(cute_aux_tensors, aux_scalars),
             ])
+            # Dropout RNG state. Only the sm120 CpAsync forward __call__ takes
+            # (dropout_seed, dropout_offset) right before stream; supply them
+            # (None when disabled) to keep positional binding correct. The TMA
+            # path and other arches don't have these params.
+            if arch // 10 == 12 and not _sm120_is_tma:
+                if dropout_p > 0.0:
+                    _seed = dropout_seed if dropout_seed is not None else torch.randint(
+                        0, 2**63 - 1, (1,), dtype=torch.int64
+                    ).item()
+                    compile_args.append(cutlass.Int64(_seed))
+                    compile_args.append(cutlass.Int64(dropout_offset))
+                else:
+                    compile_args.append(None)
+                    compile_args.append(None)
             compile_args.append(current_stream)
             _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
                 *compile_args, options="--enable-tvm-ffi"
@@ -1135,6 +1156,16 @@ def _flash_attn_fwd(
                 else None,
                 AuxData(aux_tensors, aux_scalars),
             ])
+            if arch // 10 == 12 and not _sm120_is_tma:
+                if dropout_p > 0.0:
+                    _seed_rt = dropout_seed if dropout_seed is not None else torch.randint(
+                        0, 2**63 - 1, (1,), dtype=torch.int64
+                    ).item()
+                    call_args.append(cutlass.Int64(_seed_rt))
+                    call_args.append(cutlass.Int64(dropout_offset))
+                else:
+                    call_args.append(None)
+                    call_args.append(None)
             _flash_attn_fwd.compile_cache[compile_key](*call_args)
     if is_split_kv:
         _flash_attn_fwd_combine(
@@ -1333,6 +1364,9 @@ def _flash_attn_bwd(
     aux_scalars: Optional[tuple] = None,
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     dlse: Optional[torch.Tensor] = None,
+    dropout_p: float = 0.0,
+    dropout_seed: Optional[int] = None,
+    dropout_offset: int = 0,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     aux_scalars = tuple(aux_scalars) if aux_scalars else None
     arch = _get_device_arch()
@@ -1768,6 +1802,7 @@ def _flash_attn_bwd(
             # Prevent TVM stride poisoning when only one block is present.
             (seqlen_q_rounded // m_block_size == 1),
             (seqlen_k_rounded // n_block_size == 1),
+            dropout_p > 0.0,
         )
     else:
         compile_key = (
@@ -1850,6 +1885,7 @@ def _flash_attn_bwd(
                 score_mod=score_mod,
                 score_mod_bwd=score_mod_bwd,
                 has_aux_tensors=aux_tensors is not None,
+                dropout_p=dropout_p,
             )
         elif arch // 10 == 9:
             fa_bwd_obj = FlashAttentionBackwardSm90(
@@ -1939,7 +1975,7 @@ def _flash_attn_bwd(
         dq_accum_tensor = dq_tensor if use_dedicated_hd256_kernel else dq_accum_tensor
 
         # TODO: check @can_implement
-        _flash_attn_bwd.compile_cache[compile_key] = cute.compile(
+        _bwd_compile_args = [
             fa_bwd_obj,
             q_tensor,
             k_tensor,
@@ -1962,12 +1998,24 @@ def _flash_attn_bwd(
             dV_semaphore_tensor,
             AuxData(cute_aux_tensors, aux_scalars),
             sparse_tensors_compile,
-            current_stream,
+        ]
+        # sm120/sm80 backward __call__ takes (dropout_seed, dropout_offset) before stream.
+        if arch // 10 in [8, 12]:
+            if dropout_p > 0.0:
+                _bwd_seed = dropout_seed if dropout_seed is not None else 0
+                _bwd_compile_args.append(cutlass.Int64(_bwd_seed))
+                _bwd_compile_args.append(cutlass.Int64(dropout_offset))
+            else:
+                _bwd_compile_args.append(None)
+                _bwd_compile_args.append(None)
+        _bwd_compile_args.append(current_stream)
+        _flash_attn_bwd.compile_cache[compile_key] = cute.compile(
+            *_bwd_compile_args,
             options="--enable-tvm-ffi",
         )
     if not is_fake_mode():
         dq_accum = dq if use_dedicated_hd256_kernel else dq_accum
-        _flash_attn_bwd.compile_cache[compile_key](
+        _bwd_call_args = [
             q.detach(),
             k.detach(),
             v.detach(),
@@ -2000,7 +2048,16 @@ def _flash_attn_bwd(
             )
             if normalized_block_sparse_tensors is not None
             else None,
-        )
+        ]
+        if arch // 10 in [8, 12]:
+            if dropout_p > 0.0:
+                _bwd_seed_rt = dropout_seed if dropout_seed is not None else 0
+                _bwd_call_args.append(cutlass.Int64(_bwd_seed_rt))
+                _bwd_call_args.append(cutlass.Int64(dropout_offset))
+            else:
+                _bwd_call_args.append(None)
+                _bwd_call_args.append(None)
+        _flash_attn_bwd.compile_cache[compile_key](*_bwd_call_args)
     # Postprocess: convert dq_accum from float32 to dq in bf16/fp16
     # hd=256 2CTA backward has its own internal postprocess, skip here.
     if not use_dedicated_hd256_kernel:
@@ -2069,6 +2126,7 @@ class FlashAttnFunc(torch.autograd.Function):
         block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
         block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
         return_lse: bool = False,
+        dropout_p: float = 0.0,
     ):
         aux_scalars = tuple(aux_scalars) if aux_scalars else None
         shared_kv = k is v
@@ -2078,6 +2136,11 @@ class FlashAttnFunc(torch.autograd.Function):
             # by setting q, k to None
             qv = q if qv is None else qv
             q = k = None
+        # Generate a single dropout RNG seed in the forward pass and reuse it in the
+        # backward so both regenerate the IDENTICAL keep-mask. offset=0 for now.
+        dropout_seed = None
+        if dropout_p > 0.0:
+            dropout_seed = int(torch.randint(0, 2**62, (1,), dtype=torch.int64).item())
         out, lse = _flash_attn_fwd(
             q,
             k,
@@ -2098,6 +2161,9 @@ class FlashAttnFunc(torch.autograd.Function):
             block_sparse_tensors=block_sparse_tensors,
             return_lse=return_lse,
             gather_kv_indices=gather_kv_indices,
+            dropout_p=dropout_p,
+            dropout_seed=dropout_seed,
+            dropout_offset=0,
         )
         ctx.save_for_backward(q, k, v, out, lse, *(aux_tensors or ()))
         ctx.softmax_scale = softmax_scale
@@ -2111,6 +2177,8 @@ class FlashAttnFunc(torch.autograd.Function):
         ctx.mask_mod = mask_mod
         ctx.aux_scalars = aux_scalars
         ctx.block_sparse_tensors_bwd = block_sparse_tensors_bwd
+        ctx.dropout_p = dropout_p
+        ctx.dropout_seed = dropout_seed
         ctx.set_materialize_grads(False)
         return out, lse
 
@@ -2142,8 +2210,11 @@ class FlashAttnFunc(torch.autograd.Function):
             aux_scalars=ctx.aux_scalars,
             block_sparse_tensors=ctx.block_sparse_tensors_bwd,
             dlse=dlse,
+            dropout_p=ctx.dropout_p,
+            dropout_seed=ctx.dropout_seed,
+            dropout_offset=0,
         )
-        return dq, dk, dv, *((None,) * 31)
+        return dq, dk, dv, *((None,) * 32)
 
 
 class FlashAttnVarlenFunc(torch.autograd.Function):
@@ -2303,6 +2374,7 @@ def flash_attn_func(
     block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
     block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
     return_lse: bool = False,
+    dropout_p: float = 0.0,
 ):
     return FlashAttnFunc.apply(
         q,
@@ -2326,6 +2398,7 @@ def flash_attn_func(
         block_sparse_tensors,
         block_sparse_tensors_bwd,
         return_lse,
+        dropout_p,
     )
 
 

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -460,13 +460,11 @@ def _flash_attn_fwd(
     qhead_per_kvhead = num_head // num_head_kv
     if pack_gqa is None:
         pack_gqa = qhead_per_kvhead > 1
-    # SM120 (Blackwell GeForce / RTX PRO / DGX Spark): the pack_gqa packed-coordinate
-    # O-store path is not functional on this arch (crd2idx fails on the (h_idx, m_idx)
-    # packed gmem tensor in pack_gqa.store_O). GQA is handled correctly via the standard
-    # per-head path, which is at perf parity on sm_120, so force-disable pack_gqa here
-    # regardless of how it was requested. Numerics are identical.
-    if pack_gqa and torch.cuda.get_device_capability(v.device)[0] == 12:
-        pack_gqa = False
+    # SM120 (Blackwell GeForce / RTX PRO / DGX Spark): pack_gqa is now wired through
+    # the SM80/SM120 CpAsync forward kernel (Q-load + head-indexing + epilogue), so it
+    # works correctly. The previous force-disable is left here (commented) for review.
+    # if pack_gqa and torch.cuda.get_device_capability(v.device)[0] == 12:
+    #     pack_gqa = False
 
     is_fp8 = v.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
     requires_grad = any(t is not None and t.requires_grad for t in [q, k, v, qv])

--- a/flash_attn/cute/interface.py
+++ b/flash_attn/cute/interface.py
@@ -38,6 +38,7 @@ from flash_attn.cute.flash_fwd import FlashAttentionForwardSm80
 from flash_attn.cute.flash_fwd_sm90 import FlashAttentionForwardSm90
 from flash_attn.cute.flash_fwd_sm100 import FlashAttentionForwardSm100, DescaleTensors
 from flash_attn.cute.flash_fwd_sm120 import FlashAttentionForwardSm120
+from flash_attn.cute.flash_fwd_sm120_tma import FlashAttentionForwardSm120Tma
 from flash_attn.cute.flash_bwd_preprocess import FlashAttentionBackwardPreprocess
 from flash_attn.cute.flash_bwd import FlashAttentionBackwardSm80
 from flash_attn.cute.flash_bwd_sm90 import FlashAttentionBackwardSm90
@@ -456,6 +457,12 @@ def _flash_attn_fwd(
     qhead_per_kvhead = num_head // num_head_kv
     if pack_gqa is None:
         pack_gqa = qhead_per_kvhead > 1
+        # SM120 (Blackwell GeForce / RTX PRO / DGX Spark): the pack_gqa packed-coordinate
+        # O-store path is not functional on this arch (crd2idx on the (h_idx, m_idx) packed
+        # gmem tensor). GQA is handled correctly via the standard per-head path, which is at
+        # perf parity on sm_120, so disable pack_gqa by default here.
+        if pack_gqa and torch.cuda.get_device_capability(q.device)[0] == 12:
+            pack_gqa = False
 
     is_fp8 = v.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
     requires_grad = any(t is not None and t.requires_grad for t in [q, k, v, qv])
@@ -516,9 +523,12 @@ def _flash_attn_fwd(
 
     current_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
-    # SM80/SM120: uses SM80 MMA, 128 threads (4 warps)
-    if arch // 10 in [8, 12]:
+    # SM80/SM120: uses SM80 MMA. SM120 uses 8 MMA warps to halve acc reg/thread
+    # (acc_S 64+acc_O 128 -> 32+64) and eliminate ~17 MB of local spilling.
+    if arch // 10 == 8:
         num_threads = 128
+    elif arch // 10 == 12:
+        num_threads = 256
 
     fwd_cfg = FwdConfig(128, 128, True, True)  # default
     if tile_mn is None:
@@ -945,25 +955,49 @@ def _flash_attn_fwd(
         elif arch // 10 == 12:
             # SM120 (Blackwell GeForce / DGX Spark): uses SM80 MMA with SM120 SMEM capacity
             assert not use_block_sparsity, "Block sparsity not supported on SM 12.0"
-            assert page_table is None, "Paged KV not supported on SM 12.0 in this PR"
-            assert not is_split_kv, "SplitKV not supported on SM 12.0 in this PR"
-            fa_fwd = FlashAttentionForwardSm120(
-                dtype,
-                head_dim,
-                head_dim_v,
-                qhead_per_kvhead,
-                is_causal=causal,
-                is_local=local,
-                pack_gqa=pack_gqa,
-                tile_m=tile_m,
-                tile_n=tile_n,
-                num_stages=1,
-                num_threads=num_threads,
-                Q_in_regs=False,
-                score_mod=score_mod,
-                mask_mod=mask_mod,
-                has_aux_tensors=aux_tensors is not None,
-            )
+            # TMA kernel when: no paged KV, no varlen, and not pack_gqa.
+            # pack_gqa O-store is not yet supported in the TMA epilogue; the CpAsync
+            # fallback handles GQA correctly and is at perf parity on sm_120.
+            is_varlen = cu_seqlens_q is not None or cu_seqlens_k is not None
+            use_tma_sm120 = (page_table is None and not is_varlen and not pack_gqa)
+            if use_tma_sm120 and FlashAttentionForwardSm120Tma.can_implement(
+                dtype, head_dim, head_dim_v, tile_m, tile_n,
+                num_mma_warps=8, kv_stages=2, is_causal=causal,
+            ):
+                fa_fwd = FlashAttentionForwardSm120Tma(
+                    dtype,
+                    head_dim,
+                    head_dim_v,
+                    qhead_per_kvhead,
+                    is_causal=causal,
+                    is_local=local,
+                    pack_gqa=pack_gqa,
+                    tile_m=tile_m,
+                    tile_n=tile_n,
+                    num_mma_warps=8,
+                    kv_stages=2,
+                    score_mod=score_mod,
+                    mask_mod=mask_mod,
+                    has_aux_tensors=aux_tensors is not None,
+                )
+            else:
+                fa_fwd = FlashAttentionForwardSm120(
+                    dtype,
+                    head_dim,
+                    head_dim_v,
+                    qhead_per_kvhead,
+                    is_causal=causal,
+                    is_local=local,
+                    pack_gqa=pack_gqa,
+                    tile_m=tile_m,
+                    tile_n=tile_n,
+                    num_stages=1,
+                    num_threads=num_threads,
+                    Q_in_regs=False,
+                    score_mod=score_mod,
+                    mask_mod=mask_mod,
+                    has_aux_tensors=aux_tensors is not None,
+                )
         else:
             raise ValueError(
                 f"Unsupported compute capability: {arch}. Supported: 8.x, 9.x, 10.x, 11.x, 12.x"
@@ -1326,7 +1360,6 @@ def _flash_attn_bwd(
         use_2cta_instrs = False
         num_threads = 128
         assert not (block_sparse_tensors is not None), "Block sparsity backward not supported on SM 12.0"
-        assert score_mod is None and score_mod_bwd is None, "score_mod backward not supported on SM 12.0"
         assert mask_mod is None, "mask_mod backward not supported on SM 12.0"
         assert deterministic is False, "deterministic backward not supported on SM 12.0"
     elif arch // 10 == 9:
@@ -1468,8 +1501,6 @@ def _flash_attn_bwd(
         assert cu_seqlens_q is None and cu_seqlens_k is None, (
             "varlen + score_mod not supported in bwd yet"
         )
-        if arch // 10 == 8:
-            raise NotImplementedError("Custom user-provided score_mod is not supported on SM8x architectures.")
 
     device = q.device
     out_torch_dtype = q.dtype
@@ -1641,7 +1672,7 @@ def _flash_attn_bwd(
     else:
         spt = (causal or local) and deterministic
 
-    if arch // 10 in [8, 9, 12]:
+    if arch // 10 in [8, 9]:
         compile_key = (
             arch,
             dtype,
@@ -1675,6 +1706,49 @@ def _flash_attn_bwd(
             mask_mod_hash,
             num_aux_tensors,
             aux_scalar_metadata,
+            use_block_sparsity,
+            block_sparse_broadcast_pattern,
+            get_broadcast_dims(q),
+            get_broadcast_dims(k),
+            get_broadcast_dims(v),
+            get_broadcast_dims(dout),
+            # Prevent TVM stride poisoning when only one block is present.
+            (seqlen_q_rounded // m_block_size == 1),
+            (seqlen_k_rounded // n_block_size == 1),
+        )
+    elif arch // 10 == 12:
+        compile_key = (
+            arch,
+            dtype,
+            head_dim,
+            head_dim_v,
+            qhead_per_kvhead,
+            causal,
+            window_size_left is not None,
+            window_size_right is not None,
+            m_block_size,
+            n_block_size,
+            num_threads,
+            pack_gqa,
+            num_stages_Q,
+            num_stages_dO,
+            SdP_swapAB,
+            dKV_swapAB,
+            dQ_swapAB,
+            AtomLayoutMSdP,
+            AtomLayoutNdKV,
+            AtomLayoutMdQ,
+            V_in_regs,
+            # dQ_single_wg,
+            deterministic,
+            cu_seqlens_q is None,
+            cu_seqlens_k is None,
+            seqused_q is None,
+            seqused_k is None,
+            score_mod_hash,
+            score_mod_bwd_hash,
+            mask_mod_hash,
+            num_aux_tensors,
             use_block_sparsity,
             block_sparse_broadcast_pattern,
             get_broadcast_dims(q),
@@ -1765,6 +1839,7 @@ def _flash_attn_bwd(
                 V_in_regs=V_in_regs,
                 score_mod=score_mod,
                 score_mod_bwd=score_mod_bwd,
+                has_aux_tensors=aux_tensors is not None,
             )
         elif arch // 10 == 9:
             fa_bwd_obj = FlashAttentionBackwardSm90(

--- a/flash_attn/cute/philox.py
+++ b/flash_attn/cute/philox.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2025, Tri Dao.
+# Philox4x32 counter-based RNG + dropout helpers for FA4 CuTe-DSL kernels.
+#
+# Bit-exact with csrc/flash_attn/src/philox.cuh (6 loop rounds + 1 final round)
+# and csrc/flash_attn/src/dropout.h indexing. Used to apply dropout to the
+# attention probabilities P after softmax (forward) and to regenerate the
+# identical keep-mask during the backward pass.
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32, Int64, Float32, const_expr
+
+PHILOX_A = 0xD2511F53
+PHILOX_B = 0xCD9E8D57
+PHILOX_W0 = 0x9E3779B9
+PHILOX_W1 = 0xBB67AE85
+
+
+@cute.jit
+def _mulhi_u32(a: Int32, b: Int32) -> Int32:
+    """High 32 bits of the UNSIGNED 32x32 product (int32 is signed in the DSL)."""
+    a64 = a.to(Int64) & Int64(0xFFFFFFFF)
+    b64 = b.to(Int64) & Int64(0xFFFFFFFF)
+    return ((a64 * b64) >> 32).to(Int32)
+
+
+@cute.jit
+def philox_4x32(seed: Int64, subsequence: Int64, offset: Int64):
+    """Return a 4-tuple of uint32 (as Int32) random words: philox(seed, subsequence, offset).
+
+    Matches the 7-round (6 loop + 1 final) Philox in philox.cuh exactly.
+    """
+    k0 = (seed & Int64(0xFFFFFFFF)).to(Int32)
+    k1 = ((seed >> 32) & Int64(0xFFFFFFFF)).to(Int32)
+    c0 = (offset & Int64(0xFFFFFFFF)).to(Int32)
+    c1 = ((offset >> 32) & Int64(0xFFFFFFFF)).to(Int32)
+    c2 = (subsequence & Int64(0xFFFFFFFF)).to(Int32)
+    c3 = ((subsequence >> 32) & Int64(0xFFFFFFFF)).to(Int32)
+    for _ in cutlass.range_constexpr(6):
+        hi0 = _mulhi_u32(Int32(PHILOX_A), c0)
+        lo0 = Int32(PHILOX_A) * c0
+        hi1 = _mulhi_u32(Int32(PHILOX_B), c2)
+        lo1 = Int32(PHILOX_B) * c2
+        c0, c1, c2, c3 = hi1 ^ c1 ^ k0, lo1, hi0 ^ c3 ^ k1, lo0
+        k0 = k0 + Int32(PHILOX_W0)
+        k1 = k1 + Int32(PHILOX_W1)
+    hi0 = _mulhi_u32(Int32(PHILOX_A), c0)
+    lo0 = Int32(PHILOX_A) * c0
+    hi1 = _mulhi_u32(Int32(PHILOX_B), c2)
+    lo1 = Int32(PHILOX_B) * c2
+    return hi1 ^ c1 ^ k0, lo1, hi0 ^ c3 ^ k1, lo0
+
+
+@cute.jit
+def uniform_from_uint32(x: Int32) -> Float32:
+    """Map a uint32 to a Float32 in [0, 1) (24-bit mantissa, like curand_uniform)."""
+    # take top 24 bits -> [0, 2^24) -> scale by 2^-24
+    u = (x.to(Int64) & Int64(0xFFFFFFFF))
+    top = (u >> 8).to(Int32)  # 24 bits
+    return top.to(Float32) * Float32(1.0 / 16777216.0)
+
+
+@cute.jit
+def keep_threshold_u32(p_keep: Float32) -> Int32:
+    """uint32 threshold: keep a draw if (uint32 >> 8) < round(p_keep * 2^24).
+
+    Using the same 24-bit space as uniform_from_uint32 so the test is
+    `uniform < p_keep`.
+    """
+    thr = cute.math.floor(p_keep * Float32(16777216.0))
+    return thr.to(Int32)
+
+
+@cute.jit
+def apply_dropout(
+    acc_S: cute.Tensor,        # post-softmax probabilities P (will be modified in-place)
+    tScS: cute.Tensor,         # identity tensor: tScS[i] = (q_idx, kv_idx) global coords
+    seed: Int64,
+    offset: Int64,
+    p_keep: Float32,           # 1 - dropout_p
+    scale: Float32,            # 1 / (1 - dropout_p)
+    batch_idx: Int32,
+    head_idx: Int32,
+    num_heads: cutlass.Constexpr[int],
+    seqlen_k: Int32,
+):
+    """Apply inverted dropout to P in-place, keyed by global (batch, head, q_idx, kv_idx).
+
+    Layout-agnostic: each element's RNG draw is determined solely by its global
+    coordinates, so the forward pass and the backward recompute generate the
+    IDENTICAL keep-mask regardless of fragment layout.
+    """
+    n_vals = cutlass.const_expr(cute.size(acc_S.shape))
+    bh = batch_idx * Int32(num_heads) + head_idx
+    for i in cutlass.range(n_vals, unroll_full=True):
+        q_idx = tScS[i][0]
+        kv_idx = tScS[i][1]
+        # Global linear element id within this (batch, head) plane.
+        lin = q_idx.to(Int64) * seqlen_k.to(Int64) + kv_idx.to(Int64)
+        subseq = bh.to(Int64)
+        r0, r1, r2, r3 = philox_4x32(seed, subseq, offset + lin)
+        u = uniform_from_uint32(r0)  # [0, 1)
+        keep = u < p_keep
+        acc_S[i] = acc_S[i] * scale if keep else Float32(0.0)
+

--- a/flash_attn/cute/philox.py
+++ b/flash_attn/cute/philox.py
@@ -83,18 +83,27 @@ def apply_dropout(
     head_idx: Int32,
     num_heads: cutlass.Constexpr[int],
     seqlen_k: Int32,
+    transpose_indices: cutlass.Constexpr[bool] = False,
 ):
     """Apply inverted dropout to P in-place, keyed by global (batch, head, q_idx, kv_idx).
 
     Layout-agnostic: each element's RNG draw is determined solely by its global
     coordinates, so the forward pass and the backward recompute generate the
-    IDENTICAL keep-mask regardless of fragment layout.
+    IDENTICAL keep-mask regardless of fragment layout. When ``transpose_indices``
+    is set (backward SdP_swapAB), tScS[i] holds (kv_idx, q_idx) instead of
+    (q_idx, kv_idx), so we swap accordingly.
     """
     n_vals = cutlass.const_expr(cute.size(acc_S.shape))
     bh = batch_idx * Int32(num_heads) + head_idx
+    if cutlass.const_expr(transpose_indices):
+        q_pos = cutlass.const_expr(1)
+        kv_pos = cutlass.const_expr(0)
+    else:
+        q_pos = cutlass.const_expr(0)
+        kv_pos = cutlass.const_expr(1)
     for i in cutlass.range(n_vals, unroll_full=True):
-        q_idx = tScS[i][0]
-        kv_idx = tScS[i][1]
+        q_idx = tScS[i][q_pos]
+        kv_idx = tScS[i][kv_pos]
         # Global linear element id within this (batch, head) plane.
         lin = q_idx.to(Int64) * seqlen_k.to(Int64) + kv_idx.to(Int64)
         subseq = bh.to(Int64)

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -489,9 +489,17 @@ def atomic_add_fp32(a: float | Float32, gmem_ptr: cute.Pointer, *, loc=None, ip=
     #     is_align_stack=False,
     #     asm_dialect=llvm.AsmDialect.AD_ATT,
     # )
-    nvvm.atomicrmw(
-        res=T.f32(), op=nvvm.AtomicOpKind.FADD, ptr=gmem_ptr.llvm_ptr, a=Float32(a).ir_value()
-    )
+    # The nvvm.atomicrmw binding signature differs across CUTLASS-DSL CUDA toolkit
+    # builds: cu12.9 takes (res=, op=, ptr=, a=) while cu13 takes (op, ptr, a) with
+    # the result type inferred. Support both so the kernel works regardless of which
+    # nvidia-cutlass-dsl libs variant is installed.
+    _a = Float32(a).ir_value()
+    try:
+        nvvm.atomicrmw(nvvm.AtomicOpKind.FADD, gmem_ptr.llvm_ptr, _a)
+    except TypeError:
+        nvvm.atomicrmw(
+            res=T.f32(), op=nvvm.AtomicOpKind.FADD, ptr=gmem_ptr.llvm_ptr, a=_a
+        )
 
 
 @dsl_user_op

--- a/flash_attn/cute/utils.py
+++ b/flash_attn/cute/utils.py
@@ -197,18 +197,18 @@ def compute_softmax_scale_log2(softmax_scale, score_mod):
         return LOG2_E, softmax_scale
 
 
-def compute_fastdiv_mods(mQ, mK, qhead_per_kvhead, pack_gqa, aux_tensors, mPageTable=None):
+def compute_fastdiv_mods(mQ, mK, qhead_per_kvhead, pack_gqa, aux_tensors, mPageTable=None, seqlen_dim=0):
     """Compute FastDivmodDivisor pairs for aux_tensors index computation.
 
     Returns a (seqlen_q_divmod, seqlen_k_divmod) tuple, or None if aux_tensors is None.
     """
     if const_expr(aux_tensors is None):
         return None
-    seqlen_q = cute.size(mQ.shape[0]) // (qhead_per_kvhead if const_expr(pack_gqa) else 1)
+    seqlen_q = cute.size(mQ.shape[seqlen_dim]) // (qhead_per_kvhead if const_expr(pack_gqa) else 1)
     seqlen_k = (
-        cute.size(mK.shape[0])
+        cute.size(mK.shape[seqlen_dim])
         if const_expr(mPageTable is None)
-        else mK.shape[0] * mPageTable.shape[1]
+        else mK.shape[seqlen_dim] * mPageTable.shape[1]
     )
     return (FastDivmodDivisor(seqlen_q), FastDivmodDivisor(seqlen_k))
 


### PR DESCRIPTION
## Summary

Brings the FA4 CuTe-DSL **SM120** (Blackwell GeForce / RTX PRO / DGX Spark) path to feature parity and fixes correctness regressions with `nvidia-cutlass-dsl 4.5.2`. Consolidates the relevant open upstream work and adapts it to this fork's current APIs.

Verified end-to-end on **RTX PRO 6000 Blackwell** (sm_120, cc 12.0), torch 2.12.0+cu130, cutlass-dsl 4.5.2.

## What's included

**Forward** — new `flash_fwd_sm120_tma.py` (based on upstream #2349 / #2599):
- TMA (`cp.async.bulk`) loads + warp specialization: 1 DMA warp + 8 MMA warps.
- 8 MMA warps halve accumulator regs/thread (acc_S 64→32, acc_O 128→64), eliminating the ~17 MB local-memory spilling that 4 warps caused on causal.
- Adapted to this fork's `AuxData` API (`aux_data=` on `apply_mask`, `self.score_vec_size`) vs the PR's older `aux_tensors` API.
- Dispatch: TMA when no paged-KV / no varlen / no pack_gqa; CpAsync fallback otherwise.

**Backward** — full position-dependent `score_mod` / `score_mod_bwd` for sm80/sm120 (upstream #2654): `apply_score_mod` / `apply_score_mod_bwd` via `apply_score_mod_inner`; `compute_fastdiv_mods` gains `seqlen_dim` for BSHD vs THD; tile-scheduler args indexed from the back to support both layouts.

**SM120 correctness fixes** (the original sm120 fwd/bwd were fully broken on cutlass-dsl 4.5.2):
- `use_tma_O` gated to `sm_90 <= arch < sm_120` (issue #2649): sm_120 lacks the WGMMA-era TMA-store epilogue and crashed on `tma_atom_O=None`.
- CpAsync sm120 fallback no longer passes the unsupported `is_split_kv` kwarg.
- `pack_gqa` defaulted off on sm_120 (packed-coord O-store `crd2idx` not functional there); GQA handled via the standard per-head path at perf parity.

## Validation (bf16, vs torch SDPA / flex reference)
- fwd: MHA hd64/96/128 causal+noncausal, GQA 16/4, varlen — max abs err ≤ ~1.5e-2 (bf16 tolerance).
- bwd: dq/dk/dv and score_mod bwd (times_two/squared) — rel L2 ~ bf16 noise floor.
- perf: ~350 TFLOPS noncausal hd128; TMA and CpAsync at parity on this chip (RTX PRO 6000 is bandwidth-saturated; the 5090 sees the +3–11% from #2599).

## Not included
- Dropout (#2436): Philox4x32 is implemented and bit-exact in CuTe DSL (unit-tested), but full fwd+bwd wiring is a separate, larger change — follow-up.